### PR TITLE
Add `--aws-prefer-cname` option to external AWS config 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.2.1] 2020-05-29
+
+### Changed
+
+- Prefer CNAMEs record sets for AWS SDK configuration with explicit credentials.
+
 ## [v1.2.0] 2020-02-04
 
 ### Changed

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
         {{- if eq .Values.aws.access "external" }}
         - --domain-filter={{ .Values.aws.baseDomain }}
         - --aws-zone-type=public
+        - --aws-prefer-cname
         {{- else }}
         - --domain-filter={{ .Values.baseDomain }}
         {{- end }}


### PR DESCRIPTION
By default  external-dns will create an ALIAS type records, and in case external configuration ( like China) this does not work and DNS resolution does not work. Using CNAMEs for such cases is better.