### PR TITLE
Upgrade to external-dns 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade upstream external-dns from v0.5.18 to v0.7.2.
+
 ## [v1.2.1] 2020-05-29
 
 ### Changed
@@ -58,6 +64,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Network policy that allows all egress traffic.
 - Network policy that allows accessing metrics on port `10254`.
 
+[Unreleased]: https://github.com/giantswarm/external-dns-app/compare/v1.2.1...master
 [v1.2.1]: https://github.com/giantswarm/external-dns-app/releases/tag/v1.2.1
 [v1.2.0]: https://github.com/giantswarm/external-dns-app/releases/tag/v1.2.0
 [v1.1.0]: https://github.com/giantswarm/external-dns-app/releases/tag/v1.1.0

--- a/helm/external-dns-app/Chart.yaml
+++ b/helm/external-dns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.5.18
+appVersion: v0.7.2
 description: A Helm chart for the external-dns
 home: https://github.com/giantswarm/external-dns-app
 name: external-dns-app

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
       initContainers:
       - name: wait-for-iam-role
-        image: {{ .Values.image.registry }}/giantswarm/alpine:3.10
+        image: {{ .Values.image.registry }}/giantswarm/alpine:3.12.0
         command:
         - /bin/sh
         - -c

--- a/helm/external-dns-app/templates/rbac.yaml
+++ b/helm/external-dns-app/templates/rbac.yaml
@@ -8,6 +8,9 @@ metadata:
     app: {{ .Values.name }}
 rules:
 - apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
   resources: ["services"]
   verbs: ["get","watch","list"]
 - apiGroups: [""]
@@ -18,7 +21,7 @@ rules:
   verbs: ["get","watch","list"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list"]
+  verbs: ["watch","list"]
 - apiGroups:
   - extensions
   resources:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -34,6 +34,7 @@ metricsPort: 10254
 image:
   registry: quay.io
   name: giantswarm/external-dns
+  # When updating tag make sure to also keep appVersion in Chart.yaml in sync
   tag: v0.7.2
 
 resources:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -34,7 +34,7 @@ metricsPort: 10254
 image:
   registry: quay.io
   name: giantswarm/external-dns
-  tag: v0.5.18
+  tag: v0.7.2
 
 resources:
   limits:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11356

Applied already RBAC changes needed for migration from 0.7.1 to 0.7.2.
Still TODO is to:
- [x] check rest of the upstream changelog >0.5.18 until 0.7.2. There could be breaking changes affecting our customers that we need to at least document. There could be changes (like RBAC) which are not breaking for our customers but to work fully require our helm chart to be changed.