### PR TITLE
only create secret if access key and secret are in the values file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Only template Secret if both required values are present in `values.yaml`. ([#53](https://github.com/giantswarm/external-dns-app/pull/53))
+
 ## [2.0.0] - 2021-02-03
 
 ### Changed

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.provider "aws") (eq .Values.aws.access "external") }}
+{{ if and (eq .Values.provider "aws") (eq .Values.aws.access "external") .Values.aws.credentials.awsAccessKeyID .Values.aws.credentials.awsAccessSecretKey }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->
When we install external-dns in China the secret is pre-created - the chart doesn't need create it. instead we should only create the secret if both values exist in the values file.
