### PR TITLE
revert location of AWS API credentials in values file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert location of AWS API credentials in `values.yaml`. ([#57](https://github.com/giantswarm/external-dns-app/pull/57))
+
 ## [2.0.1] - 2021-02-03
 
 ### Changed

--- a/helm/external-dns-app/Configuration.md
+++ b/helm/external-dns-app/Configuration.md
@@ -9,13 +9,13 @@ and are are optional unless otherwise stated.
 | aws.access                         | string | `"internal"` | Authenticate via KIAM or credentials **(required)** |
 | aws.baseDomain                     | string | `nil`        | Base domain of the cluster |
 | aws.batchChangeSize                | int    | `nil`        | How many records to synchronise in a batch |
-| aws.credentials.awsAccessKeyID     | string | `nil`        | Access key (required when aws.access is 'external') |
-| aws.credentials.awsAccessSecretKey | string | `nil`        | Secret key (required when aws.access is 'external') |
 | aws.iam.customRoleName             | string | `nil`        | Custom IAM role for KIAM to assume |
 | aws.preferCNAME                    | bool   | `false`      | Prefer CNAME records over ALIAS |
 | aws.region                         | string | `nil`        | Region (required when aws.access is 'external') |
 | aws.zoneType                       | string | `nil`        | Hosted zone types to update |
 | externalDNS.annotationFilter       | string | `"giantswarm.io/external-dns=managed"` | Only reconcile Service/Ingress with this annotation |
+| externalDNS.aws_access_key_id      | string | `nil`        | Access key (required when aws.access is 'external') |
+| externalDNS.aws_secret_access_key  | string | `nil`        | Secret key (required when aws.access is 'external') |
 | externalDNS.domainFilterList       | list   | `[]`         | List of domains to update |
 | externalDNS.interval               | string | `nil`        | Synchronisation interval |
 | externalDNS.namespaceFilter        | string | `"kube-system"` | Filter namespace to watch endpoints in |

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.provider "aws") (eq .Values.aws.access "external") .Values.aws.credentials.awsAccessKeyID .Values.aws.credentials.awsAccessSecretKey }}
+{{ if and (eq .Values.provider "aws") (eq .Values.aws.access "external") .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +7,8 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 data:
-  aws_access_key_id: {{ .Values.aws.credentials.awsAccessKeyID | b64enc }}
-  aws_secret_access_key: {{ .Values.aws.credentials.awsAccessSecretKey | b64enc }}
+  aws_access_key_id: {{ .Values.externalDNS.aws_access_key_id | b64enc }}
+  aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}
 type: Opaque
 {{ end -}}
 

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -14,17 +14,6 @@
                 "batchChangeSize": {
                     "type": ["null", "integer"]
                 },
-                "credentials": {
-                    "type": "object",
-                    "properties": {
-                        "awsAccessKeyID": {
-                            "type": ["null", "string"]
-                        },
-                        "awsAccessSecretKey": {
-                            "type": ["null", "string"]
-                        }
-                    }
-                },
                 "iam": {
                     "type": "object",
                     "properties": {
@@ -58,6 +47,13 @@
             "properties": {
                 "annotationFilter": {
                     "type": "string"
+                },
+                },
+                "aws_access_key_id": {
+                    "type": ["null", "string"]
+                },
+                "aws_secret_access_key": {
+                    "type": ["null", "string"]
                 },
                 "domainFilterList": {
                     "type": "array"

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -15,19 +15,6 @@ aws:
   # can update public and private zones.
   access: internal
 
-  # aws.credentials
-  # Credentials used to authenticate against the AWS API - only required when
-  # aws.access is 'external'.
-  credentials:
-
-    # aws.credentials.awsAccessKeyID
-    # Access key ID for the AWS API.
-    awsAccessKeyID:
-
-    # aws.credentials.awsAccessSecretKey
-    # Access key secret for the AWS API.
-    awsAccessSecretKey:
-
   # aws.baseDomain
   # If aws.access is 'external' then the domain to update must be set.
   baseDomain:
@@ -72,6 +59,14 @@ externalDNS:
   # `externalDNS.sources` to limit futher. This must be provided when running multiple
   # instances of external-dns.
   annotationFilter: "giantswarm.io/external-dns=managed"
+
+  # externalDNS.aws_access_key_id
+  # Access key ID for the AWS API. Only required when aws.access is 'external'.
+  aws_access_key_id:
+
+  # externalDNS.aws_secret_access_key
+  # Access key secret for the AWS API. Only required when aws.access is 'external'.
+  aws_secret_access_key:
 
   # externalDNS.domainFilterList
   # One or more domains that this instance of external-dns will manage. If


### PR DESCRIPTION
<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->

This PR:
- fixes deployment in China. AWS API credentials are provided in a different location in the values file so we need to accomodate that.
