### PR TITLE
Add flags and improve chart safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Allow the sync policy to be configured. ([#60](https://github.com/giantswarm/external-dns-app/pull/60))
+- Supports customisation of the txt-owner-id (whilst still defaulting for default apps). ([#60](https://github.com/giantswarm/external-dns-app/pull/60))
+- Supports dry-run mode and warns the user if enabled. ([#60](https://github.com/giantswarm/external-dns-app/pull/60))
+
+### Changed
+
+- Rework the way the txt prefix is generated (whilst still defaulting for default apps). ([#60](https://github.com/giantswarm/external-dns-app/pull/60))
+- Rework how the annotation filter value is generated (whilst still defaulting for default app). ([#60](https://github.com/giantswarm/external-dns-app/pull/60))
+
 ## [2.0.2] - 2021-02-04
 
 ### Fixed

--- a/helm/external-dns-app/templates/NOTES.txt
+++ b/helm/external-dns-app/templates/NOTES.txt
@@ -1,1 +1,6 @@
+{{- if .Values.externalDNS.dryRun }}
+INFO: external-dns is in dry-run mode; changes
+      will be logged but _not_ applied.
+{{- end }}
+
 {{- include "externalDNS.validateValues" . }}

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -83,6 +83,20 @@ from the default catalog and is therefore a default app */}}
 {{- end -}}
 
 {{/*
+Set the txt record prefix.
+*/}}
+{{- define "txt.prefix" -}}
+{{- if .Values.NetExporter -}}
+{{/* if this value is present then the app was installed
+from the default catalog and is therefore a default app */}}
+{{- printf "%s" .Values.clusterID }}
+{{- else -}}
+{{/* the customer must provide their own */}}
+{{- printf "%s" .Values.externalDNS.registry.txtPrefix }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate certain values and fail if they are incorrect
 */}}
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -69,6 +69,20 @@ Set the role name for KIAM
 {{- end }}
 
 {{/*
+Set the txt owner ID.
+*/}}
+{{- define "txt.owner.id" -}}
+{{- if .Values.NetExporter -}}
+{{/* if this value is present then the app was installed
+from the default catalog and is therefore a default app */}}
+{{- print "giantswarm-io-external-dns" }}
+{{- else -}}
+{{/* the customer must provide their own */}}
+{{- printf "%s" .Values.externalDNS.registry.txtOwnerID }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate certain values and fail if they are incorrect
 */}}
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -69,6 +69,20 @@ Set the role name for KIAM
 {{- end }}
 
 {{/*
+Set the annotation filter.
+*/}}
+{{- define "annotation.filter" -}}
+{{- if .Values.NetExporter -}}
+{{/* if this value is present then the app was installed
+from the default catalog and is therefore a default app */}}
+{{- print "giantswarm.io/external-dns=managed" }}
+{{- else -}}
+{{/* the customer must provide their own */}}
+{{- printf "%s" .Values.externalDNS.annotationFilter }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set the txt owner ID.
 */}}
 {{- define "txt.owner.id" -}}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -68,9 +68,7 @@ spec:
         - --source={{ . }}
         {{- end }}
         - --policy={{ .Values.externalDNS.policy }}
-        {{- if .Values.externalDNS.annotationFilter }}
-        - --annotation-filter={{ .Values.externalDNS.annotationFilter }}
-        {{- end }}
+        - --annotation-filter={{- template "annotation.filter" . }}
         {{- if .Values.externalDNS.interval }}
         - --interval={{ .Values.externalDNS.interval }}
         {{- end }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -67,6 +67,7 @@ spec:
         {{- range .Values.externalDNS.sources }}
         - --source={{ . }}
         {{- end }}
+        - --policy={{ .Values.externalDNS.policy }}
         {{- if .Values.externalDNS.annotationFilter }}
         - --annotation-filter={{ .Values.externalDNS.annotationFilter }}
         {{- end }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -94,12 +94,7 @@ spec:
         {{- end }}
         - --registry=txt
         - --txt-owner-id={{- template "txt.owner.id" . }}
-        {{- if .Values.externalDNS.registry.txtPrefix }}
-        - --txt-prefix={{ .Values.externalDNS.registry.txtPrefix }}
-        {{- else }}
-        - --txt-prefix={{ .Values.clusterID }}
-        {{- end }}
-
+        - --txt-prefix={{- template "txt.prefix" . }}
         readinessProbe:
           httpGet:
             path: /healthz

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -92,12 +92,13 @@ spec:
         - --namespace={{ .Values.externalDNS.namespaceFilter }}
         {{- end }}
         - --registry=txt
-        - --txt-owner-id=giantswarm-io-external-dns
+        - --txt-owner-id={{- template "txt.owner.id" . }}
         {{- if .Values.externalDNS.registry.txtPrefix }}
         - --txt-prefix={{ .Values.externalDNS.registry.txtPrefix }}
         {{- else }}
         - --txt-prefix={{ .Values.clusterID }}
         {{- end }}
+
         readinessProbe:
           httpGet:
             path: /healthz

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
           value: {{ .Values.aws.region }}
         {{- end }}
         args:
+        {{- if .Values.externalDNS.dryRun }}
+        - --dry-run=true
+        {{- end }}
         {{- range .Values.externalDNS.sources }}
         - --source={{ . }}
         {{- end }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -57,17 +57,26 @@
                 "domainFilterList": {
                     "type": "array"
                 },
+                "dryRun": {
+                    "type": "boolean"
+                },
                 "interval": {
                     "type": ["null", "string"]
                 },
                 "namespaceFilter": {
                     "type": "string"
                 },
+                "policy": {
+                    "type": "string"
+                },
                 "registry": {
                     "type": "object",
                     "properties": {
+                        "txtOwnerID": {
+                            "type": "string"
+                        },
                         "txtPrefix": {
-                            "type": ["null", "string"]
+                            "type": "string"
                         }
                     }
                 },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -58,7 +58,7 @@ externalDNS:
   # Annotation to filter objects to reconcile. Use in conjunction with
   # `externalDNS.sources` to limit futher. This must be provided when running multiple
   # instances of external-dns.
-  annotationFilter: "giantswarm.io/external-dns=managed"
+  annotationFilter: "external-dns/managed-app=true"
 
   # externalDNS.aws_access_key_id
   # Access key ID for the AWS API. Only required when aws.access is 'external'.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -90,6 +90,10 @@ externalDNS:
   # namespaces will be used.
   namespaceFilter: kube-system
 
+  # externalDNS.policy
+  # Syncing policy between sources and providers.
+  policy: sync
+
   # externalDNS.registry
   # Configuration options relating to ownership of created records.
   registry:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -106,7 +106,7 @@ externalDNS:
     # externalDNS.registry.txtPrefix
     # String prefix applied to TXT registry records. See
     # https://github.com/kubernetes-sigs/external-dns/blob/master/docs/proposal/registry.md
-    txtPrefix:
+    txtPrefix: extdns
 
   # externalDNS.sources
   # Resource types queried for endpoints.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -94,6 +94,11 @@ externalDNS:
   # Configuration options relating to ownership of created records.
   registry:
 
+    # externalDNS.registry.txtOwnerID
+    # String to identify this instance of external-dns and the records it owns. See
+    # https://github.com/kubernetes-sigs/external-dns/blob/master/docs/proposal/registry.md
+    txtOwnerID: managed-external-dns
+
     # externalDNS.registry.txtPrefix
     # String prefix applied to TXT registry records. See
     # https://github.com/kubernetes-sigs/external-dns/blob/master/docs/proposal/registry.md

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -77,6 +77,10 @@ externalDNS:
   # - foo.bar.com
   # - baz.bar.com
 
+  # externalDNS.dryRun
+  # Dry run logs what action external-dns would have taken, but doesn't apply them.
+  dryRun: false
+
   # externalDNS.interval
   # Interval between synchronisations. Must be in duration format (e.g. `5m`)
   interval:


### PR DESCRIPTION
<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->
This PR:
- Supports dry-run mode and warns the user if enabled.
- Supports customisation of the txt-owner-id (with defaulting for default app).
- Allows the sync policy to be configured.
- Reworks the way the txt prefix is generated (with defaulting for default app).
- Reworks how the annotation filter value is generated (with defaulting for default app).
