### PR TITLE
always use CNAMEs on aws when access is external

### DIFF
--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         {{- end -}}
         {{- if eq .Values.provider "aws" }}
         {{- include "zone.type" . | nindent 8 }}
-        {{- if .Values.aws.preferCNAME }}
+        {{- if or .Values.aws.preferCNAME (eq .Values.aws.access "external") }}
         - --aws-prefer-cname
         {{- end }}
         {{- if .Values.aws.batchChangeSize }}

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -35,7 +35,7 @@ aws:
     customRoleName:
 
   # aws.preferCNAME
-  # Create CNAME records instead of ALIAS. Should be set to true when aws.access
+  # Create CNAME records instead of ALIAS. Will always be set to true when aws.access
   # is `external`.
   preferCNAME: false
 


### PR DESCRIPTION
<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->

This enforces CNAMEs usage when access is external
