### PR TITLE
Remove unnecessary annotation

### DIFF
--- a/helm/external-dns-app/templates/metrics-service.yaml
+++ b/helm/external-dns-app/templates/metrics-service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Release.Name }}-monitoring
   namespace: {{ .Release.Namespace }}
   annotations:
-    giantswarm.io/monitoring: "true"
     giantswarm.io/monitoring-path: /metrics
     giantswarm.io/monitoring-port: {{ .Values.global.metrics.port | quote }}
   labels:


### PR DESCRIPTION
<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->

This annotation was replaced by a label and is no longer needed after giantswarm/giantswarm#10909.
