### PR TITLE
add crd source if running on vmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add crd source if the provider is vmware. ([#72](https://github.com/giantswarm/external-dns-app/pull/72))
+
 ## [2.1.1] - 2021-02-08
 
 ### Fixed

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -138,7 +138,7 @@ don't expose that value to the user in the error message.
 {{- define "validateValues.provider" -}}
 {{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "vmware") (ne .Values.provider "inmemory") -}}
 external-dns: provider
-    Incorrect value provided. Valid values are either 'aws' or 'azure'.
+    Incorrect value provided. Valid values are either 'aws', 'azure' or 'vmware'.
 {{- end -}}
 {{- end -}}
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -136,7 +136,7 @@ Validate that the provider makes sense
 don't expose that value to the user in the error message.
 */}}
 {{- define "validateValues.provider" -}}
-{{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "inmemory") -}}
+{{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "vmware") (ne .Values.provider "inmemory") -}}
 external-dns: provider
     Incorrect value provided. Valid values are either 'aws' or 'azure'.
 {{- end -}}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
         {{- range .Values.externalDNS.sources }}
         - --source={{ . }}
         {{- end }}
+        {{- if eq .Values.provider "vmware" }}
+        - --source=crd
+        {{- end }}
         - --policy={{ .Values.externalDNS.policy }}
         - --annotation-filter={{- template "annotation.filter" . }}
         {{- if .Values.externalDNS.interval }}


### PR DESCRIPTION
<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->
We need the `crd` source type when running on vmware clusters.
