### PR TITLE
add missed requirements for running on vmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Adds additional options required for vmware installations. ([#74](https://github.com/giantswarm/external-dns-app/pull/74))
+
 ## [2.2.0] - 2021-03-24
 
 ### Added

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -111,6 +111,16 @@ from the default catalog and is therefore a default app */}}
 {{- end -}}
 
 {{/*
+Set the provider type (VMWare clusters use Route53 for DNS). Ternary
+function returns `aws` if provider is vmware; otherwise it returns
+the value of .Values.provider.
+*/}}
+{{- define "dnsProvider.name" -}}
+{{ $dnsProvider :=  ternary "aws" .Values.provider (eq .Values.provider "vmware")}}
+{{ printf "- --provider=%s" $dnsProvider }}
+{{- end }}
+
+{{/*
 Validate certain values and fail if they are incorrect
 */}}
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         {{- if .Values.externalDNS.interval }}
         - --interval={{ .Values.externalDNS.interval }}
         {{- end }}
-        - --provider={{ .Values.provider }}
+        {{- include "dnsProvider.name" . | nindent 8 }}
         {{- if eq .Values.provider "azure" }}
         - --azure-config-file=/azure/config/azure.yaml
         {{- end -}}

--- a/helm/external-dns-app/templates/rbac.yaml
+++ b/helm/external-dns-app/templates/rbac.yaml
@@ -29,6 +29,22 @@ rules:
   - {{ .Release.Name }}
   verbs:
   - use
+{{- if eq .Values.provider "vmware" }}
+- apiGroups:
+  - externaldns.k8s.io
+  resources:
+  - dnsendpoints/status
+  verbs:
+  - update
+- apiGroups:
+  - externaldns.k8s.io
+  resources:
+  - dnsendpoints
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.provider "aws") (eq .Values.aws.access "external") .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+{{ if and (or (eq .Values.provider "aws") (eq .Values.provider "vmware")) (eq .Values.aws.access "external") .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/16298

My previous vmware-related PR was rather naively optimistic - I missed a bunch of necessary changes.

This PR:
- creates aws external access secret for vmware
- adds required rbac for dnsendpoints when running on vmware
- moves provider logic to helpers file

<!--
@app-squad-external-dns will be automatically requested for review once
this PR has been submitted.
-->
