### PR TITLE
Change default annotation filter to match nginx ingress controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change default annotation filter to match the one we use for the nginx ingress controller.
+
 ### Added
 
 - Add sidecar container for `provider: aws` to periodically validate IAM credential acessibility ([#76](https://github.com/giantswarm/external-dns-app/pull/76))

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -58,7 +58,7 @@ externalDNS:
   # Annotation to filter objects to reconcile. Use in conjunction with
   # `externalDNS.sources` to limit futher. This must be provided when running multiple
   # instances of external-dns.
-  annotationFilter: "external-dns/managed-app=true"
+  annotationFilter: "giantswarm.io/external-dns=managed"
 
   # externalDNS.aws_access_key_id
   # Access key ID for the AWS API. Only required when aws.access is 'external'.


### PR DESCRIPTION
See this thread for details: https://gigantic.slack.com/archives/CR99LSZ1N/p1617115996023200

TL;DR

recently we changed the annotation filter used by external dns to check which `Services` to take care of when it has to create DNS records.
The annotation filter doesn't match by default the service created by nginx ingress controller app.

Result: latest version of external dns app and latest version of nginx ingress controller app don't work together.

This PR aims at making the filter and the [nginx ingress controller annotation](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/helm/nginx-ingress-controller-app/values.yaml#L228) to match.