### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -4,4 +4,4 @@ chart-dir: ./helm/external-dns-app
 destination: ./build
 skip-steps: test_all
 # CI overwrites this, check .circleci/config.yaml
-catalog-base-url: https://giantswarm.github.com/default-catalog/
+catalog-base-url: https://giantswarm.github.io/default-catalog/


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898