### PR TITLE
Bump external-dns to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Upgrade upstream external-dns from v0.7.6 to [v0.8.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.8.0).
-- Allow to configure the minimum interval between two consecutive synchronizations triggered from kubernetes events though `externalDNS.minEventSyncInterval`.
+- Allow to configure the minimum interval between two consecutive synchronizations triggered from kubernetes events through `externalDNS.minEventSyncInterval`.
 
 ## [2.3.1] - 2021-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Upgrade upstream external-dns from v0.7.6 to [v0.8.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.8.0).
+- Allow to configure the minimum interval between two consecutive synchronizations triggered from kubernetes events though `externalDNS.minEventSyncInterval`.
 
 ## [2.3.1] - 2021-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade upstream external-dns from v0.7.6 to [v0.8.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.8.0).
+
 ## [2.3.1] - 2021-05-20
 
 ### Changed

--- a/helm/external-dns-app/Chart.yaml
+++ b/helm/external-dns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.7.6
+appVersion: v0.8.0
 description: Configure external DNS servers for Kubernetes Ingresses and Services
 engine: gotpl
 home: https://github.com/giantswarm/external-dns-app
@@ -10,4 +10,4 @@ sources:
 annotations:
     application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/external-dns-app/v[[ .Version ]]/helm/external-dns-app/values.schema.json
     application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/external-dns-app/v[[ .Version ]]/README.md
-version: 2.2.1
+version: 2.4.0

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
         - --namespace={{ .Values.externalDNS.namespaceFilter }}
         {{- end }}
         {{- if .Values.externalDNS.minEventSyncInterval }}
-        --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
+        - --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
         {{- end }}
         - --registry=txt
         - --txt-owner-id={{- template "txt.owner.id" . }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
         {{- if .Values.externalDNS.namespaceFilter }}
         - --namespace={{ .Values.externalDNS.namespaceFilter }}
         {{- end }}
+        {{- if .Values.externalDNS.minEventSyncInterval }}
+        --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
+        {{- end }}
         - --registry=txt
         - --txt-owner-id={{- template "txt.owner.id" . }}
         - --txt-prefix={{- template "txt.prefix" . }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -66,6 +66,9 @@
                 "namespaceFilter": {
                     "type": "string"
                 },
+                "minEventSyncInterval": {
+                    "type": "string"
+                },
                 "policy": {
                     "type": "string"
                 },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -90,6 +90,11 @@ externalDNS:
   # namespaces will be used.
   namespaceFilter: kube-system
 
+  # externalDNS.minEventSyncInterval
+  # The minimum interval between two consecutive synchronizations triggered from
+  # kubernetes events in duration format (default: 5s)
+  minEventSyncInterval: 10s
+
   # externalDNS.policy
   # Syncing policy between sources and providers.
   policy: sync

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -129,7 +129,7 @@ global:
 
     # global.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync.
-    tag: v0.7.6
+    tag: v0.8.0
 
   # global.metrics
   # Metrics configuration options


### PR DESCRIPTION
This PR updates the used external-dns version to 0.8.0

It also allows users to configure the --min-event-sync-internal flag

- [x] tested on aws
- [ ] azure test in progress