### PR TITLE
Upgrade to external-dns v0.9.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,30 @@
 @app-squad-external-dns will be automatically requested for review once
 this PR has been submitted.
 -->
+
+This PR:
+
+
+
+---
+
+## Checklist
+
+- [ ] Added a CHANGELOG entry
+
+## Testing
+
+### Default app on AWS releases
+
+- [ ] Fresh install works
+- [ ] Upgrade works
+
+### Default app on Azure releases
+
+- [ ] Fresh install works
+- [ ] Upgrade works
+
+### Optional app (KVM)
+
+- [ ] Fresh install works
+- [ ] Upgrade works

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Upgrade upstream external-dns from v0.8.0 to [v0.9.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.9.0).
+- Upgrade upstream external-dns from v0.8.0 to [v0.9.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.9.0). The new release brings a lot of smaller improvements and bug fixes.
 
 ## [2.4.0] - 2021-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade upstream external-dns from v0.8.0 to [v0.9.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.9.0).
+
 ## [2.4.0] - 2021-06-16
 
 ### Changed

--- a/helm/external-dns-app/Chart.yaml
+++ b/helm/external-dns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.8.0
+appVersion: v0.9.0
 description: Configure external DNS servers for Kubernetes Ingresses and Services
 engine: gotpl
 home: https://github.com/giantswarm/external-dns-app
@@ -10,4 +10,4 @@ sources:
 annotations:
     application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/external-dns-app/v[[ .Version ]]/helm/external-dns-app/values.schema.json
     application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/external-dns-app/v[[ .Version ]]/README.md
-version: 2.4.0
+version: 2.5.0

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "{{ .Values.global.metrics.port }}"
         prometheus.io/scrape: "{{ .Values.global.metrics.scrape }}"
+        kubectl.kubernetes.io/default-logs-container: "{{ .Release.Name }}"
     spec:
       serviceAccountName: {{ .Release.Name }}
       securityContext:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -134,7 +134,7 @@ global:
 
     # global.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync.
-    tag: v0.8.0
+    tag: v0.9.0
 
   # global.metrics
   # Metrics configuration options


### PR DESCRIPTION
This PR upgrades external-dns to 0.9.0

TODO:

- [x] Wait for 0.9.0 image to be available (`k8s.gcr.io/external-dns/external-dns:v0.9.0`)
- [x] Re-execute `retagger` CI to copy the image into our quay.io and aliyun repositories
- [x] Re-execute tests

@giantswarm/app-squad-external-dns feel free to take over