### PR TITLE
Capz support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support for CAPZ clusters by detecting the Azure configuration file location.
+
 ## [2.5.0] - 2021-08-18
 
 ### Changed

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -49,11 +49,11 @@ spec:
           - /bin/sh
           - -c
           # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
+          # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
           - if [ -f /etc/kubernetes/config/azure.yaml ]; \
             then \
             cp /etc/kubernetes/config/azure.yaml /config/azure.yaml; \
             else \
-          # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
             cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml; \
             fi
         volumeMounts:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -33,14 +33,28 @@ spec:
         runAsGroup: {{ .Values.global.securityContext.groupID }}
         fsGroup: {{ .Values.global.securityContext.fsGroupID }}
       priorityClassName: giantswarm-critical
-      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
       initContainers:
+      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
       - name: wait-for-iam-role
         image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
         command:
         - /bin/sh
         - -c
         - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
+      {{- end }}
+      {{- if eq .Values.provider "azure" }}
+      - name: copy-azure-config-file
+        image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
+        command:
+          - /bin/sh
+          - -c
+          - if [ -f /etc/kubernetes/config/azure.yaml ]; then cp /etc/kubernetes/config/azure.yaml /config/azure.yaml; else cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml; fi
+        volumeMounts:
+          - mountPath: /etc/kubernetes
+            name: etc-kubernetes
+            readOnly: true
+          - mountPath: /config
+            name: config
       {{- end }}
       containers:
       {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
@@ -90,7 +104,7 @@ spec:
         {{- end }}
         {{- include "dnsProvider.name" . | nindent 8 }}
         {{- if eq .Values.provider "azure" }}
-        - --azure-config-file=/azure/config/azure.yaml
+        - --azure-config-file=/config/azure.yaml
         {{- end -}}
         {{- if eq .Values.provider "aws" }}
         {{- include "zone.type" . | nindent 8 }}
@@ -134,15 +148,13 @@ spec:
           protocol: TCP
       {{- if eq .Values.provider "azure" }}
         volumeMounts:
-        - name: azure-config-file
-          mountPath: /azure/config
+        - name: config
+          mountPath: /config
           readOnly: true
-        - mountPath: /azure
-          name: azure-config-file-ownership
       volumes:
-      - name: azure-config-file
+      - name: config
+        emptyDir: {}
+      - name: etc-kubernetes
         hostPath:
-          path: /etc/kubernetes/config
-      - emptyDir: {}
-        name: azure-config-file-ownership
+          path: /etc/kubernetes
       {{- end }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -48,7 +48,14 @@ spec:
         command:
           - /bin/sh
           - -c
-          - if [ -f /etc/kubernetes/config/azure.yaml ]; then cp /etc/kubernetes/config/azure.yaml /config/azure.yaml; else cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml; fi
+          # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
+          - if [ -f /etc/kubernetes/config/azure.yaml ]; \
+            then \
+            cp /etc/kubernetes/config/azure.yaml /config/azure.yaml; \
+            else \
+          # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
+            cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml; \
+            fi
         volumeMounts:
           - mountPath: /etc/kubernetes
             name: etc-kubernetes

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -50,11 +50,11 @@ spec:
           - -c
           # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
           # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
-          - if [ -f /etc/kubernetes/config/azure.yaml ]; \
-            then \
-            cp /etc/kubernetes/config/azure.yaml /config/azure.yaml; \
-            else \
-            cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml; \
+          - if [ -f /etc/kubernetes/config/azure.yaml ];
+            then
+            cp /etc/kubernetes/config/azure.yaml /config/azure.yaml;
+            else
+            cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml;
             fi
         volumeMounts:
           - mountPath: /etc/kubernetes

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       {{- if eq .Values.provider "azure" }}
       - name: copy-azure-config-file
-        image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
+        image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12-python3
         command:
           - /bin/sh
           - -c


### PR DESCRIPTION
CAPZ clusters have a different path and type for the cloud config file.
This PR aims at making this app compatible with both GS and CAPZ clusters, by ensuring that the cloud config file is a known location (/config/azure.yaml) and type (yaml rather than json).
It does that by using an initContainer that is only executed when the app is installed in an azure cluster.


---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
