### PR TITLE
Add the ability to specify extra arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add ability to specify extra arguments to the external-dns deployment through `externalDNS.extraArgs`.
+
 ## [2.7.0] - 2021-12-16
 
 ### Changed

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -133,6 +133,9 @@ spec:
         - --registry=txt
         - --txt-owner-id={{- template "txt.owner.id" . }}
         - --txt-prefix={{- template "txt.prefix" . }}
+      {{- range .Values.externalDNS.extraArgs }}
+        - {{ . }}
+      {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
         readinessProbe:

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -60,6 +60,10 @@
                 "dryRun": {
                     "type": "boolean"
                 },
+                "extraArgs": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
                 "interval": {
                     "type": ["null", "string"]
                 },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -120,6 +120,10 @@ externalDNS:
   # Disable ingress source by default.
   # - ingress
 
+  # externalDNS.extraArgs
+  # Allows to specify additional arguments to the external-dns deployment.
+  extraArgs: []
+
 global:
 
   # global.image


### PR DESCRIPTION
This PR adds the ability to specify extra arguments to the external-dns deployment.

This would allow users to add additional arguments like `--aws-zones-cache-duration`, `--aws-batch-change-interval` and `--zone-id-filter`.