### PR TITLE
use unreleased ats to test on newer kubernetes versions

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -3,7 +3,9 @@ app-tests-app-config-file: tests/test-values.yaml
 skip-steps: functional
 
 smoke-tests-cluster-type: kind
+smoke-tests-cluster-config-file: tests/kind_config.yaml
 
 upgrade-tests-cluster-type: kind
+upgrade-tests-cluster-config-file: tests/kind_config.yaml
 upgrade-tests-app-catalog-url: https://giantswarm.github.io/default-catalog
 upgrade-tests-app-config-file: tests/test-values.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
 
       - architect/run-tests-with-ats:
           name: execute chart tests
+          app-test-suite_container_tag: "0.2.3-beta.1-0e9d820873a1701cb8a7d8796614fafb00ac0771"
           filters:
             # Do not trigger the job on merge to master.
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,18 @@ workflows:
             tags:
               only: /^v.*/
 
+      # Require manual approval for running tests.
+      - hold-tests:
+          name: "Hold app tests on kubernetes gt 1.21"
+          type: approval
+          filters:
+            # Do not trigger the job on master branch or release tags.
+            branches:
+              ignore:
+                - master
+            tags:
+              ignore: /^v.*/
+
       - architect/run-tests-with-ats:
           name: execute chart tests
           filters:
@@ -40,3 +52,29 @@ workflows:
                 - master
           requires:
             - "package and push to default catalog"
+
+      - architect/run-tests-with-ats:
+          name: execute chart tests on 1.22
+          app-test-suite_container_tag: "0.2.3-beta.1-0e9d820873a1701cb8a7d8796614fafb00ac0771"
+          additional_app-test-suite_flags: "--kind-cluster-image-override=kindest/node:v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978"
+          filters:
+            # Do not trigger the job on merge to master.
+            branches:
+              ignore:
+                - master
+          requires:
+            - "package and push to default catalog"
+            - "Hold app tests on kubernetes gt 1.21"
+
+      - architect/run-tests-with-ats:
+          name: execute chart tests on 1.23
+          app-test-suite_container_tag: "0.2.3-beta.1-0e9d820873a1701cb8a7d8796614fafb00ac0771"
+          additional_app-test-suite_flags: "--kind-cluster-image-override=kindest/node:v1.23.1@sha256:355a1e3b7b0fe315c896f63a73847c554aac8fb8615c6bf47f1ca303009e9a2d"
+          filters:
+            # Do not trigger the job on merge to master.
+            branches:
+              ignore:
+                - master
+          requires:
+            - "package and push to default catalog"
+            - "Hold app tests on kubernetes gt 1.21"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ workflows:
 
       - architect/run-tests-with-ats:
           name: execute chart tests
-          app-test-suite_container_tag: "0.2.3-beta.1-0e9d820873a1701cb8a7d8796614fafb00ac0771"
+          app-test-suite_container_tag: "0.2.3-beta.1-6743792e7dfbb3def8e81ddc080bd3a8f27e07a5"
           filters:
             # Do not trigger the job on merge to master.
             branches:
@@ -56,7 +56,7 @@ workflows:
 
       - architect/run-tests-with-ats:
           name: execute chart tests on 1.22
-          app-test-suite_container_tag: "0.2.3-beta.1-0e9d820873a1701cb8a7d8796614fafb00ac0771"
+          app-test-suite_container_tag: "0.2.3-beta.1-6743792e7dfbb3def8e81ddc080bd3a8f27e07a5"
           additional_app-test-suite_flags: "--kind-cluster-image-override=kindest/node:v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978"
           filters:
             # Do not trigger the job on merge to master.
@@ -69,7 +69,7 @@ workflows:
 
       - architect/run-tests-with-ats:
           name: execute chart tests on 1.23
-          app-test-suite_container_tag: "0.2.3-beta.1-0e9d820873a1701cb8a7d8796614fafb00ac0771"
+          app-test-suite_container_tag: "0.2.3-beta.1-6743792e7dfbb3def8e81ddc080bd3a8f27e07a5"
           additional_app-test-suite_flags: "--kind-cluster-image-override=kindest/node:v1.23.1@sha256:355a1e3b7b0fe315c896f63a73847c554aac8fb8615c6bf47f1ca303009e9a2d"
           filters:
             # Do not trigger the job on merge to master.

--- a/tests/ats/Pipfile
+++ b/tests/ats/Pipfile
@@ -4,10 +4,13 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-pytest-helm-charts = ">=0.6.0"
+pytest-helm-charts = "==0.7.0b2"
 pytest = ">=6.2.5"
 pykube-ng = ">=21.10.0"
 pytest-rerunfailures = ">=10.2"
 
 [requires]
 python_version = "3.9"
+
+[pipenv]
+allow_prereleases = true

--- a/tests/ats/Pipfile.lock
+++ b/tests/ats/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
-                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.2.0"
+            "version": "==21.4.0"
         },
         "certifi": {
             "hashes": [
@@ -33,11 +33,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
-                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
+                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.7"
+            "version": "==2.0.10"
         },
         "deprecated": {
             "hashes": [
@@ -167,11 +167,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
-                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.26.0"
+            "version": "==2.27.1"
         },
         "toml": {
             "hashes": [
@@ -183,11 +183,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.7"
+            "version": "==1.26.8"
         },
         "wrapt": {
             "hashes": [

--- a/tests/ats/Pipfile.lock
+++ b/tests/ats/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "adac50f656014e5ea0366e335ea9d9529ad8ec246c87fe8a27c81be170c63f4d"
+            "sha256": "55293ec1cf25df90eaad201aa92f9d0c92e8fc18a0b297cf86d239d8fe2f8f0f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -112,11 +112,11 @@
         },
         "pytest-helm-charts": {
             "hashes": [
-                "sha256:13972a00a9705bda2e9923e641528f76470cfd3abade54290060bef9cb7d3d66",
-                "sha256:a94451c08f7f85525e6089ec23fccf11c324468d32cf3a3a1e59a6a0927a5501"
+                "sha256:19aada4e426b927f1a91ec0c811c079f2363cff21cf9f1674e6fda8a31dd84f8",
+                "sha256:c7099df7b413416c216763b0fa904ec155b7ea07d9f7e2fe27e949ae6f1c3bea"
             ],
             "index": "pypi",
-            "version": "==0.6.0"
+            "version": "==0.7.0b2"
         },
         "pytest-rerunfailures": {
             "hashes": [
@@ -186,7 +186,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.8"
         },
         "wrapt": {

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -3,8 +3,8 @@ from typing import Dict, List
 
 import pykube
 import pytest
-from pytest_helm_charts.fixtures import Cluster
-from pytest_helm_charts.utils import wait_for_deployments_to_run
+from pytest_helm_charts.clusters import Cluster
+from pytest_helm_charts.k8s.deployment import wait_for_deployments_to_run
 
 logger = logging.getLogger(__name__)
 

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
