### PR TITLE
Provider flag and env handling refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+This release contains some changes to mitigate rate limiting on AWS clusters. Please take note of the default
+values of values `aws.batchChangeInterval`, `aws.zonesCacheDuration`, `externalDNS.interval`
+and `externalDNS.minEventSyncInterval`.
+
+If you already specify `--aws-batch-change-interval` or `--aws-zones-cache-duration`, please migrate to the new values `aws.batchChangeInterval` and `aws.zonesCacheDuration`.
+
+### Added
+
+- Allow to set `--aws-batch-change-interval` through `aws.batchChangeInterval` value. Default `10s`.
+- Allow to set `--aws-zones-cache-duration` through `aws.zonesCacheDuration` value. Default `3h`.
+
+### Changed
+
+- Set default `externalDNS.interval` to `5m`.
+- Set default `externalDNS.minEventSyncInterval` to `30s`.
+- Allow setting Route53 credentials (`externalDNS.aws_access_key_id` and `externalDNS.aws_secret_access_key`) indepentent from `aws.access` value.
+- Allow setting the AWS default region (`aws.region`) indepentent from `aws.access` value.
+- Allow to omit the `--domain-filter` flag completely by setting `externalDNS.domainFilterList` to `null`.
+
 ## [2.8.0] - 2022-01-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-This release contains some changes to mitigate rate limiting on AWS clusters. Please take note of the default
-values of values `aws.batchChangeInterval`, `aws.zonesCacheDuration`, `externalDNS.interval`
+This release contains some changes to mitigate rate limiting on AWS clusters. Please take note of the defaults
+for values `aws.batchChangeInterval`, `aws.zonesCacheDuration`, `externalDNS.interval`
 and `externalDNS.minEventSyncInterval`.
 
 If you already specify `--aws-batch-change-interval` or `--aws-zones-cache-duration`, please migrate to the new values `aws.batchChangeInterval` and `aws.zonesCacheDuration`.

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
       - name: {{ .Release.Name }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: IfNotPresent
-        {{- if eq .Values.aws.access "external" }}
+        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "vmware")) .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -91,8 +91,10 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-route53-credentials
               key: aws_secret_access_key
+        {{- with .Values.aws.region }}
         - name: AWS_DEFAULT_REGION
-          value: {{ .Values.aws.region }}
+          value: {{ . }}
+        {{- end }}
         {{- end }}
         args:
         {{- if .Values.externalDNS.dryRun }}
@@ -101,28 +103,12 @@ spec:
         {{- range .Values.externalDNS.sources }}
         - --source={{ . }}
         {{- end }}
-        {{- if eq .Values.provider "vmware" }}
-        - --source=crd
-        {{- end }}
         - --policy={{ .Values.externalDNS.policy }}
         - --annotation-filter={{- template "annotation.filter" . }}
         {{- if .Values.externalDNS.interval }}
         - --interval={{ .Values.externalDNS.interval }}
         {{- end }}
-        {{- include "dnsProvider.name" . | nindent 8 }}
-        {{- if eq .Values.provider "azure" }}
-        - --azure-config-file=/config/azure.yaml
-        {{- end -}}
-        {{- if eq .Values.provider "aws" }}
-        {{- include "zone.type" . | nindent 8 }}
-        {{- if or .Values.aws.preferCNAME (eq .Values.aws.access "external") }}
-        - --aws-prefer-cname
-        {{- end }}
-        {{- if .Values.aws.batchChangeSize }}
-        - --aws-batch-change-size={{ .Values.aws.batchChangeSize }}
-        {{- end }}
-        {{- include "domain.list" . | nindent 8 }}
-        {{- end }}
+        {{- include "dnsProvider.flags" . | nindent 8 }}
         - --metrics-address=:{{ .Values.global.metrics.port }}
         {{- if .Values.externalDNS.namespaceFilter }}
         - --namespace={{ .Values.externalDNS.namespaceFilter }}

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (or (eq .Values.provider "aws") (eq .Values.provider "vmware")) (eq .Values.aws.access "external") .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+{{ if and (or (eq .Values.provider "aws") (eq .Values.provider "vmware")) .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,4 +11,3 @@ data:
   aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}
 type: Opaque
 {{ end -}}
-

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -11,6 +11,9 @@
                 "baseDomain": {
                     "type": ["null", "string"]
                 },
+                "batchChangeInterval": {
+                    "type": ["null", "string"]
+                },
                 "batchChangeSize": {
                     "type": ["null", "integer"]
                 },
@@ -29,6 +32,9 @@
                     "type": ["null", "string"]
                 },
                 "zoneType": {
+                    "type": ["null", "string"]
+                },
+                "zonesCacheDuration": {
                     "type": ["null", "string"]
                 }
             }
@@ -55,7 +61,7 @@
                     "type": ["null", "string"]
                 },
                 "domainFilterList": {
-                    "type": "array"
+                    "type": ["null", "array"]
                 },
                 "dryRun": {
                     "type": "boolean"
@@ -67,11 +73,11 @@
                 "interval": {
                     "type": ["null", "string"]
                 },
-                "namespaceFilter": {
-                    "type": "string"
-                },
                 "minEventSyncInterval": {
-                    "type": "string"
+                    "type": ["null", "string"]
+                },
+                "namespaceFilter": {
+                    "type": ["null", "string"]
                 },
                 "policy": {
                     "type": "string"

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -24,6 +24,16 @@ aws:
   # default will be used.
   batchChangeSize:
 
+  # aws.batchChangeInterval
+  # Set interval between batch changes. If left blank then the default will
+  # be used.
+  batchChangeInterval: 10s
+
+  # aws.zonesCacheDuration
+  # Set the zones list cache TTL. If left blank then the default will
+  # be used.
+  zonesCacheDuration: 3h
+
   # aws.iam
   # AWS IAM configuration.
   iam:
@@ -73,6 +83,8 @@ externalDNS:
   # no domains are provided then the cluster baseDomain must be provided via
   # either `baseDomain` or `aws.baseDomain` (depending on the Route53 access
   # method used).
+  # By explicitly setting externalDNS.domainFilterList to null, the --domain-filter
+  # flag will be completely omitted. Otherwise leave this as empty array ([])
   domainFilterList: []
   # - foo.bar.com
   # - baz.bar.com
@@ -83,7 +95,7 @@ externalDNS:
 
   # externalDNS.interval
   # Interval between synchronisations. Must be in duration format (e.g. `5m`)
-  interval:
+  interval: 5m
 
   # externalDNS.namespaceFilter
   # The namespace to limit sources of endpoints to. If left blank, all
@@ -93,7 +105,7 @@ externalDNS:
   # externalDNS.minEventSyncInterval
   # The minimum interval between two consecutive synchronizations triggered from
   # kubernetes events in duration format (default: 5s)
-  minEventSyncInterval: 10s
+  minEventSyncInterval: 30s
 
   # externalDNS.policy
   # Syncing policy between sources and providers.


### PR DESCRIPTION
This PR:

refactors the provider flags and env var handling to

- Allow to completely omit the `--domain-filter` for giantswarm/giantswarm#20432
- Allow setting Route53 credentials independent from `aws.access` value for giantswarm/roadmap#732

It also sets some defaults to mitigate getting rate limited. https://github.com/giantswarm/giantswarm/issues/20332

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [x] Fresh install works
- [x] Upgrade works

### Default app on Azure releases

- [x] Fresh install works
- [x] Upgrade works
