### PR TITLE
Image: Upgrade to v0.11.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add team ownership label.
 
+### Changed
+
+- Upgrade upstream external-dns image from [v0.10.2](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.10.2) to [v0.11.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.11.0).
+
 ## [2.9.1] - 2022-02-03
 
 ### Changed

--- a/helm/external-dns-app/Chart.yaml
+++ b/helm/external-dns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.10.2
+appVersion: v0.11.0
 description: Configure external DNS servers for Kubernetes Ingresses and Services
 home: https://github.com/giantswarm/external-dns-app
 icon: https://s.giantswarm.io/app-icons/external-dns/1/dark.png
@@ -8,5 +8,5 @@ sources:
 - https://github.com/kubernetes-sigs/external-dns
 annotations:
   application.giantswarm.io/team: team-cabbage
-version: 2.7.0
+version: 2.10.0
 kubeVersion: ">=1.19.0-0"

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -150,7 +150,7 @@ global:
 
     # global.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync.
-    tag: v0.10.2
+    tag: v0.11.0
 
   # global.metrics
   # Metrics configuration options


### PR DESCRIPTION
This also bumps the chart version to 2.10.0.

Resolves https://github.com/giantswarm/giantswarm/issues/21565.

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [x] Fresh install works
- [x] Upgrade works

### Default app on Azure releases

- [x] Fresh install works
- [x] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
