### PR TITLE
Add support for gcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Google Cloud `gcp` provider.
+
 ## [2.11.0] - 2022-05-10
 
 ### Added
 
 - Add support for `DNSEndpoint` CRs. See README for further information.
-- Add support for Google Cloud `gcp` provider.
 
 ## [2.10.0] - 2022-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add support for `DNSEndpoint` CRs. See README for further information.
+- Add support for Google Cloud `gcp` provider.
 
 ## [2.10.0] - 2022-04-20
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -125,8 +125,13 @@ function returns `aws` if provider is vmware; otherwise it returns
 the value of .Values.provider.
 */}}
 {{- define "dnsProvider.flags" -}}
-{{- $dnsProvider := ternary "aws" .Values.provider (eq .Values.provider "vmware") -}}
-{{ printf "- --provider=%s" $dnsProvider }}
+{{- $dnsProvider := .Values.provider -}}
+{{- if eq .Values.provider "vmware" }}
+{{- $dnsProvider = "aws" -}}
+{{- else if eq .Values.provider "gcp" }}
+{{- $dnsProvider = "google" -}}
+{{- end }}
+{{- printf "- --provider=%s" $dnsProvider }}
 
 {{- if eq $dnsProvider "aws" }}
 {{ include "zone.type" . }}
@@ -178,9 +183,9 @@ Validate that the provider makes sense
 don't expose that value to the user in the error message.
 */}}
 {{- define "validateValues.provider" -}}
-{{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "vmware") (ne .Values.provider "inmemory") -}}
+{{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "gcp") (ne .Values.provider "vmware") (ne .Values.provider "inmemory") -}}
 external-dns: provider
-    Incorrect value provided. Valid values are either 'aws', 'azure' or 'vmware'.
+    Incorrect value provided. Valid values are either 'aws', 'azure', 'gcp' or 'vmware'.
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
We want to use `external-dns-app` on GCP clusters. For that, we need to allow selecting the google provider. One caveat is that while we named `gcp` to the google provider, `external-dns` uses `google`, so we need to transform `gcp` into `google`.

## Checklist

- [X] Added a CHANGELOG entry
