### PR TITLE
Support IRSA for AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Support IRSA (IAM Roles for Service Accounts) for `aws` provider.
+
 ## [2.12.0] - 2022-05-13
 
 ### Added

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         {{- include "labels.common" . | nindent 8 }}
       annotations:
-        {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( not .Values.aws.irsa ) }}
+        {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
         iam.amazonaws.com/role: {{ template "aws.iam.role" . }}
         {{- end }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -34,7 +34,7 @@ spec:
         fsGroup: {{ .Values.global.securityContext.fsGroupID }}
       priorityClassName: giantswarm-critical
       initContainers:
-      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( not .Values.aws.irsa ) }}
+      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
       - name: wait-for-iam-role
         image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
         command:
@@ -64,7 +64,7 @@ spec:
             name: config
       {{- end }}
       containers:
-      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( not .Values.aws.irsa ) }}
+      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
       - name: "{{ .Release.Name }}-check-iam"
         image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
         command:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         {{- include "labels.common" . | nindent 8 }}
       annotations:
-        {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
+        {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( not .Values.aws.irsa ) }}
         iam.amazonaws.com/role: {{ template "aws.iam.role" . }}
         {{- end }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -34,7 +34,7 @@ spec:
         fsGroup: {{ .Values.global.securityContext.fsGroupID }}
       priorityClassName: giantswarm-critical
       initContainers:
-      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
+      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( not .Values.aws.irsa ) }}
       - name: wait-for-iam-role
         image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
         command:
@@ -64,7 +64,7 @@ spec:
             name: config
       {{- end }}
       containers:
-      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") }}
+      {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( not .Values.aws.irsa ) }}
       - name: "{{ .Release.Name }}-check-iam"
         image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.12.0
         command:

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{- if and (eq .Values.provider "aws") (.Values.aws.irsa) }}
+  {{- if and (eq .Values.provider "aws") (eq .Values.aws.irsa "true") }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
   {{- end }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -3,5 +3,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  {{- if and (eq .Values.provider "aws") (.Values.aws.irsa) }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
+  {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -29,7 +29,7 @@
                     }
                 },
                 "irsa": {
-                    "type": "boolean"
+                    "type": "string"
                 },
                 "preferCNAME": {
                     "type": "boolean"

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -8,6 +8,9 @@
                 "access": {
                     "type": "string"
                 },
+                "accountID": {
+                    "type": "string"
+                },
                 "baseDomain": {
                     "type": ["null", "string"]
                 },
@@ -24,6 +27,9 @@
                             "type": ["null", "string"]
                         }
                     }
+                },
+                "irsa": {
+                    "type": "boolean"
                 },
                 "preferCNAME": {
                     "type": "boolean"

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -16,7 +16,8 @@ aws:
   access: internal
 
   # aws.accountID
-  # AWS account ID to assume role via IRSA.
+  # AWS account ID is used to assume role via IAM roles for service accounts.
+  # It is dynamically set and will be overridden.
   accountID: ""
 
   # aws.baseDomain
@@ -34,7 +35,8 @@ aws:
   batchChangeInterval: 10s
 
   # aws.irsa
-  # Set to true to use IRSA to authenticate with AWS.
+  # Set to true when IAM roles for service accounts is enabled.
+  # It is dynamically set and will be overridden.
   irsa: "false"
 
   # aws.zonesCacheDuration

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -35,7 +35,7 @@ aws:
 
   # aws.irsa
   # Set to true to use IRSA to authenticate with AWS.
-  irsa: true
+  irsa: "false"
 
   # aws.zonesCacheDuration
   # Set the zones list cache TTL. If left blank then the default will

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -16,7 +16,7 @@ aws:
   access: internal
 
   # aws.accountID
-  # AWS account ID is used to assume role via IAM roles for service accounts.
+  # AWS account ID is used to assume role via IRSA (IAM roles for service accounts).
   # It is dynamically set and will be overridden.
   accountID: ""
 

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -256,4 +256,4 @@ baseDomain: gigantic.io
 # The cluster's ID. This is only used if this chart is installed as a default app
 # from the default-catalog. It is dynamically set and will be overridden. Specific
 # to Giant Swarm clusters.
-clusterID: e2jo
+clusterID: en2jo

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -15,6 +15,10 @@ aws:
   # can update public and private zones.
   access: internal
 
+  # aws.accountID
+  # AWS account ID to assume role via IRSA.
+  accountID: ""
+
   # aws.baseDomain
   # If aws.access is 'external' then the domain to update must be set.
   baseDomain:
@@ -28,6 +32,10 @@ aws:
   # Set interval between batch changes. If left blank then the default will
   # be used.
   batchChangeInterval: 10s
+
+  # aws.irsa
+  # Set to true to use IRSA to authenticate with AWS.
+  irsa: true
 
   # aws.zonesCacheDuration
   # Set the zones list cache TTL. If left blank then the default will
@@ -248,4 +256,4 @@ baseDomain: gigantic.io
 # The cluster's ID. This is only used if this chart is installed as a default app
 # from the default-catalog. It is dynamically set and will be overridden. Specific
 # to Giant Swarm clusters.
-clusterID: en2jo
+clusterID: e2jo


### PR DESCRIPTION
We will opt-out kiam in the next releases, this PR prepares to opt-in IRSA
when enabled.

Issue: https://github.com/giantswarm/roadmap/issues/1101

## Checklist

- [x] Added a CHANGELOG entry

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [x] Fresh install works
- [x] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works