### PR TITLE
Feature: VerticalPodAutoscaler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- VerticalPodAutoscaler for automatically setting requests and limits depending on usage. Fixes OOM kills on huge clusters.
+
 ## [2.13.0] - 2022-05-25
 
 ### Added

--- a/helm/external-dns-app/templates/vpa.yaml
+++ b/helm/external-dns-app/templates/vpa.yaml
@@ -1,0 +1,21 @@
+{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Release.Name }}
+      controlledValues: RequestsAndLimits
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  {{ .Release.Name }}
+  updatePolicy:
+    updateMode: Auto
+{{ end }}


### PR DESCRIPTION
This PR fixes https://github.com/giantswarm/giantswarm/issues/22105.

On some quite big clusters `external-dns` may run out of memory since there's an internal cache for pods and nodes, especially because of the latter since they are not namespaced.

Vertical pod autoscaler should increase the memory requests and limits depending on the actual memory usage of `external-dns`.

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [x] Fresh install works
- [x] Upgrade works

### Default app on Azure releases

- [x] Fresh install works
- [x] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
