### PR TITLE
Add support for GCP workload identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support for GCP workload identity for authentication.
+
 ## [2.15.1] - 2022-08-02
 
 ### Changed

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -11,9 +11,6 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
-      {{- if and (eq .Values.provider "gcp") (.Values.gcpServiceAccountID) (.Values.gcpWorkloadIdentityPool) (.Values.gcpIdentityProvider) }}
-      giantswarm.io/gcp-workload-identity: enabled
-      {{- end }}
   strategy:
     type: Recreate
   template:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels:
         {{- include "labels.common" . | nindent 8 }}
+      {{- if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
+      giantswarm.io/gcp-workload-identity: enabled
+      {{- end }}
       annotations:
         {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
         iam.amazonaws.com/role: {{ template "aws.iam.role" . }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -11,15 +11,18 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      {{- if and (eq .Values.provider "gcp") (.Values.gcpServiceAccountID) (.Values.gcpWorkloadIdentityPool) (.Values.gcpIdentityProvider) }}
+      giantswarm.io/gcp-workload-identity: enabled
+      {{- end }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         {{- include "labels.common" . | nindent 8 }}
-      {{- if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
-      giantswarm.io/gcp-workload-identity: enabled
-      {{- end }}
+        {{- if and (eq .Values.provider "gcp") (.Values.gcpServiceAccountID) (.Values.gcpWorkloadIdentityPool) (.Values.gcpIdentityProvider) }}
+        giantswarm.io/gcp-workload-identity: enabled
+        {{- end }}
       annotations:
         {{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
         iam.amazonaws.com/role: {{ template "aws.iam.role" . }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -8,9 +8,7 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
   {{- else if and (eq .Values.provider "gcp") (.Values.gcpServiceAccountID) (.Values.gcpWorkloadIdentityPool) (.Values.gcpIdentityProvider) }}
   annotations:
-    giantswarm.io/gcp-service-account: {{ .Values.gcpServiceAccountID }}
-    giantswarm.io/gcp-workload-identity-pool-id: {{ .Values.gcpWorkloadIdentityPool }}
-    giantswarm.io/gcp-identity-provider: {{ .Values.gcpIdentityProvider }}
+    giantswarm.io/gcp-service-account: 'external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
   {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -6,9 +6,11 @@ metadata:
   {{- if and (eq .Values.provider "aws") (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
-  {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
+  {{- else if and (eq .Values.provider "gcp") (.Values.gcpServiceAccountID) (.Values.gcpWorkloadIdentityPool) (.Values.gcpIdentityProvider) }}
   annotations:
-    giantswarm.io/gcp-workload-identity-pool-id: '{{ .Values.gcpProject }}.svc.id.goog'
+    giantswarm.io/gcp-service-account: {{ .Values.gcpServiceAccountID }}
+    giantswarm.io/gcp-workload-identity-pool-id: {{ .Values.gcpWorkloadIdentityPool }}
+    giantswarm.io/gcp-identity-provider: {{ .Values.gcpIdentityProvider }}
   {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if and (eq .Values.provider "aws") (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
-  {{- else if and (eq .Values.provider "gcp") }}
+  {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
   annotations:
     giantswarm.io/gcp-workload-identity-pool-id: '{{ .Values.gcpProject }}.svc.id.goog'
   {{- end }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   {{- if and (eq .Values.provider "aws") (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
+  {{- else if and (eq .Values.provider "gcp") }}
+  annotations:
+    giantswarm.io/gcp-workload-identity-pool-id: '{{ .Values.gcpProject }}.svc.id.goog'
   {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -12,19 +12,19 @@
                     "type": "string"
                 },
                 "baseDomain": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "batchChangeInterval": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "batchChangeSize": {
-                    "type": "null"
+                    "type": ["null", "integer"]
                 },
                 "iam": {
                     "type": "object",
                     "properties": {
                         "customRoleName": {
-                            "type": "null"
+                            "type": ["null", "string"]
                         }
                     }
                 },
@@ -35,13 +35,13 @@
                     "type": "boolean"
                 },
                 "region": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "zoneType": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "zonesCacheDuration": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 }
             }
         },
@@ -50,52 +50,6 @@
         },
         "clusterID": {
             "type": "string"
-        },
-        "crd": {
-            "type": "object",
-            "properties": {
-                "backoffLimit": {
-                    "type": "integer"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "install": {
-                    "type": "boolean"
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         },
         "e2e": {
             "type": "boolean"
@@ -107,28 +61,29 @@
                     "type": "string"
                 },
                 "aws_access_key_id": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "aws_secret_access_key": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "domainFilterList": {
-                    "type": "array"
+                    "type": ["null", "array"]
                 },
                 "dryRun": {
                     "type": "boolean"
                 },
                 "extraArgs": {
-                    "type": "array"
+                    "type": "array",
+                    "items": { "type": "string" }
                 },
                 "interval": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "minEventSyncInterval": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "namespaceFilter": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "policy": {
                     "type": "string"
@@ -154,6 +109,52 @@
         },
         "gcpProject": {
             "type": "string"
+        },
+        "crd": {
+            "type": "object",
+            "properties": {
+                "backoffLimit": {
+                    "type": "integer"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["string", "integer"]
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["string", "integer"]
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "global": {
             "type": "object",

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -107,7 +107,13 @@
                 }
             }
         },
-        "gcpProject": {
+        "gcpServiceAccountID": {
+            "type": "string"
+        },
+        "gcpWorkloadIdentityPool": {
+            "type": "string"
+        },
+        "gcpIdentityProvider": {
             "type": "string"
         },
         "crd": {

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -12,19 +12,19 @@
                     "type": "string"
                 },
                 "baseDomain": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "batchChangeInterval": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "batchChangeSize": {
-                    "type": ["null", "integer"]
+                    "type": "null"
                 },
                 "iam": {
                     "type": "object",
                     "properties": {
                         "customRoleName": {
-                            "type": ["null", "string"]
+                            "type": "null"
                         }
                     }
                 },
@@ -35,13 +35,13 @@
                     "type": "boolean"
                 },
                 "region": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "zoneType": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "zonesCacheDuration": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 }
             }
         },
@@ -50,6 +50,52 @@
         },
         "clusterID": {
             "type": "string"
+        },
+        "crd": {
+            "type": "object",
+            "properties": {
+                "backoffLimit": {
+                    "type": "integer"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "e2e": {
             "type": "boolean"
@@ -61,29 +107,28 @@
                     "type": "string"
                 },
                 "aws_access_key_id": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "aws_secret_access_key": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "domainFilterList": {
-                    "type": ["null", "array"]
+                    "type": "array"
                 },
                 "dryRun": {
                     "type": "boolean"
                 },
                 "extraArgs": {
-                    "type": "array",
-                    "items": { "type": "string" }
+                    "type": "array"
                 },
                 "interval": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "minEventSyncInterval": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "namespaceFilter": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "policy": {
                     "type": "string"
@@ -107,60 +152,8 @@
                 }
             }
         },
-        "gcpServiceAccount": {
+        "gcpProject": {
             "type": "string"
-        },
-        "gcpWorkloadIdentityPoolID": {
-            "type": "string"
-        },
-        "gcpIdentityProvider": {
-            "type": "string"
-        },
-        "crd": {
-            "type": "object",
-            "properties": {
-                "backoffLimit": {
-                    "type": "integer"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "install": {
-                    "type": "boolean"
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer"]
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer"]
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         },
         "global": {
             "type": "object",

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -12,19 +12,19 @@
                     "type": "string"
                 },
                 "baseDomain": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "batchChangeInterval": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "batchChangeSize": {
-                    "type": "null"
+                    "type": ["null", "integer"]
                 },
                 "iam": {
                     "type": "object",
                     "properties": {
                         "customRoleName": {
-                            "type": "null"
+                            "type": ["null", "string"]
                         }
                     }
                 },
@@ -35,13 +35,13 @@
                     "type": "boolean"
                 },
                 "region": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "zoneType": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "zonesCacheDuration": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 }
             }
         },
@@ -75,7 +75,7 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -86,7 +86,7 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -107,28 +107,29 @@
                     "type": "string"
                 },
                 "aws_access_key_id": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "aws_secret_access_key": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "domainFilterList": {
-                    "type": "array"
+                    "type": ["null", "array"]
                 },
                 "dryRun": {
                     "type": "boolean"
                 },
                 "extraArgs": {
-                    "type": "array"
+                    "type": "array",
+                    "items": { "type": "string" }
                 },
                 "interval": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "minEventSyncInterval": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "namespaceFilter": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "policy": {
                     "type": "string"

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -107,10 +107,10 @@
                 }
             }
         },
-        "gcpServiceAccountID": {
+        "gcpServiceAccount": {
             "type": "string"
         },
-        "gcpWorkloadIdentityPool": {
+        "gcpWorkloadIdentityPoolID": {
             "type": "string"
         },
         "gcpIdentityProvider": {

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -12,19 +12,19 @@
                     "type": "string"
                 },
                 "baseDomain": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "batchChangeInterval": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "batchChangeSize": {
-                    "type": ["null", "integer"]
+                    "type": "null"
                 },
                 "iam": {
                     "type": "object",
                     "properties": {
                         "customRoleName": {
-                            "type": ["null", "string"]
+                            "type": "null"
                         }
                     }
                 },
@@ -35,13 +35,13 @@
                     "type": "boolean"
                 },
                 "region": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "zoneType": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "zonesCacheDuration": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 }
             }
         },
@@ -50,6 +50,52 @@
         },
         "clusterID": {
             "type": "string"
+        },
+        "crd": {
+            "type": "object",
+            "properties": {
+                "backoffLimit": {
+                    "type": "integer"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "e2e": {
             "type": "boolean"
@@ -61,29 +107,28 @@
                     "type": "string"
                 },
                 "aws_access_key_id": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "aws_secret_access_key": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "domainFilterList": {
-                    "type": ["null", "array"]
+                    "type": "array"
                 },
                 "dryRun": {
                     "type": "boolean"
                 },
                 "extraArgs": {
-                    "type": "array",
-                    "items": { "type": "string" }
+                    "type": "array"
                 },
                 "interval": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "minEventSyncInterval": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "namespaceFilter": {
-                    "type": ["null", "string"]
+                    "type": "string"
                 },
                 "policy": {
                     "type": "string"
@@ -107,51 +152,8 @@
                 }
             }
         },
-        "crd": {
-            "type": "object",
-            "properties": {
-                "backoffLimit": {
-                    "type": "integer"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "install": {
-                    "type": "boolean"
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer"]
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer"]
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        "gcpProject": {
+            "type": "string"
         },
         "global": {
             "type": "object",

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -70,13 +70,13 @@ aws:
   # cannot be changed.
   zoneType:
 
-# gcpServiceAccountID
+# gcpServiceAccount
 # The GCP Service Account ID to use when running on gcp, using workload identity for authentication.
-gcpServiceAccountID: ""
+gcpServiceAccount: ""
 
-# gcpWorkloadIdentityPool
+# gcpWorkloadIdentityPoolID
 # The workload identity pool ID for the cluster where the app will run. It's of the form '$gcpProject.svc.id.goog'.
-gcpWorkloadIdentityPool: ""
+gcpWorkloadIdentityPoolID: ""
 
 # gcpIdentityProvider
 # The workload identity identity provider for the cluster where the app will run.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -70,9 +70,17 @@ aws:
   # cannot be changed.
   zoneType:
 
-# gcpProject
-# Used when provider is gcp so the app uses workload identity for authentication.
-gcpProject: ""
+# gcpServiceAccountID
+# The GCP Service Account ID to use when running on gcp, using workload identity for authentication.
+gcpServiceAccountID: ""
+
+# gcpWorkloadIdentityPool
+# The workload identity pool ID for the cluster where the app will run. It's of the form '$gcpProject.svc.id.goog'.
+gcpWorkloadIdentityPool: ""
+
+# gcpIdentityProvider
+# The workload identity identity provider for the cluster where the app will run.
+gcpIdentityProvider: ""
 
 # externalDNS
 # Configuration options for external-dns itself.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -70,17 +70,9 @@ aws:
   # cannot be changed.
   zoneType:
 
-# gcpServiceAccount
-# The GCP Service Account ID to use when running on gcp, using workload identity for authentication.
-gcpServiceAccount: ""
-
-# gcpWorkloadIdentityPoolID
-# The workload identity pool ID for the cluster where the app will run. It's of the form '$gcpProject.svc.id.goog'.
-gcpWorkloadIdentityPoolID: ""
-
-# gcpIdentityProvider
-# The workload identity identity provider for the cluster where the app will run.
-gcpIdentityProvider: ""
+# gcpProject
+# The GCP project in which external-dns will create records.
+gcpProject: ""
 
 # externalDNS
 # Configuration options for external-dns itself.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -70,6 +70,10 @@ aws:
   # cannot be changed.
   zoneType:
 
+# gcpProject
+# Used when provider is gcp so the app uses workload identity for authentication.
+gcpProject: ""
+
 # externalDNS
 # Configuration options for external-dns itself.
 externalDNS:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1313

The same way we have support for IRSA when authenticating with AWS, we want to use workload identity when running on GCP clusters.

---

## Checklist

- [X] Added a CHANGELOG entry
