### PR TITLE
clarify external-dns is default on azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- edited README.md ([#184](https://github.com/giantswarm/external-dns-app/pull/184))
+
 ## [2.15.2] - 2022-08-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Changed
-
-- edited README.md ([#184](https://github.com/giantswarm/external-dns-app/pull/184))
-
 ## [2.15.2] - 2022-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # external-dns-app chart
 
 Helm chart for the [external-dns](https://github.com/kubernetes-sigs/external-dns) service running in Workload
-Clusters. This chart is used to deploy both as a default app (AWS and Azure) and as a Managed App.
+Clusters. This chart is used to deploy both as a default app and as a Managed App.
 It can be installed multiple times in the same Workload Cluster.
 
 **What is this App?**
@@ -12,7 +12,7 @@ It can be installed multiple times in the same Workload Cluster.
 
 **Why did we add it?**
 
-The App is already used as a default App in AWS and Azure clusters to provide DNS records for [nginx-ingress-controller-app](https://github.com/giantswarm/nginx-ingress-controller-app).
+The App is already used as a default App in most clusters (except on-prem) to provide DNS records for [nginx-ingress-controller-app](https://github.com/giantswarm/nginx-ingress-controller-app).
 
 **Who can use it?**
 
@@ -108,6 +108,9 @@ See our [full reference page on how to configure applications](https://docs.gian
 This app has been tested to work with the following workload cluster release versions:
 
 * AWS `v13.0.0`
+* Azure `v16.0.2`
+
+Furthermore, it requires a Kubernetes version of `>= v1.19.0-0`.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # external-dns-app chart
 
 Helm chart for the [external-dns](https://github.com/kubernetes-sigs/external-dns) service running in Workload
-Clusters. This chart is used to deploy both as a default app (only required on AWS), and as a Managed App.
+Clusters. This chart is used to deploy both as a default app (AWS and Azure) and as a Managed App.
 It can be installed multiple times in the same Workload Cluster.
 
 **What is this App?**
@@ -12,7 +12,7 @@ It can be installed multiple times in the same Workload Cluster.
 
 **Why did we add it?**
 
-The App is already used as a default App in AWS clusters to provide DNS records for [nginx-ingress-controller-app](https://github.com/giantswarm/nginx-ingress-controller-app).
+The App is already used as a default App in AWS and Azure clusters to provide DNS records for [nginx-ingress-controller-app](https://github.com/giantswarm/nginx-ingress-controller-app).
 
 **Who can use it?**
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ The App is already used as a default App in AWS and Azure clusters to provide DN
 
 Customers using Giant Swarm clusters on AWS or Azure.
 
+---
+
+## Index
+- [Installing](#installing)
+- [Configuring](#configuring)
+- [Compatibility](#compatibility)
+- [Limitations](#limitations)
+- [Release Process](#release-process)
+
 ## Installing
 
 There are 3 ways to install this app onto a workload cluster:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR: edits the readme and adds information that `external-dns` is also a default app on azure. Previously it said it's only required on AWS



---

## Checklist

- [x] Added a CHANGELOG entry
