### PR TITLE
Add ciliumnetworkpoliccy for the CRD install job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Added `CiliumNetworkPolicy` for the CRD install job.
 
+### Changed
+
+- The helm job that installs CRDs is not removed if the job fails.
+
 ## [2.16.0] - 2022-11-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added `CiliumNetworkPolicy` for the CRD install job.
+
 ## [2.16.0] - 2022-11-09
 
 ### Added

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -31,7 +31,7 @@ CRD install annotations.
 */}}
 {{- define "annotations.crd" -}}
 helm.sh/hook: pre-install,pre-upgrade
-helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{/*

--- a/helm/external-dns-app/templates/crd/np.yaml
+++ b/helm/external-dns-app/templates/crd/np.yaml
@@ -3,7 +3,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ include "kyverno-stack.crdInstall" . }}
+  name: {{ .Release.Name }}-crd-install
   namespace: {{ .Release.Namespace | quote }}
   annotations:
     # create hook dependencies in the right order

--- a/helm/external-dns-app/templates/crd/np.yaml
+++ b/helm/external-dns-app/templates/crd/np.yaml
@@ -1,4 +1,31 @@
 {{- if .Values.crd.install }}
+  {{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "kyverno-stack.crdInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    {{- include "annotations.crd" . | nindent 4 }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: crd-install
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: crd-install
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+        - ports:
+            - port: "6443"
+  {{- else}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -30,4 +57,5 @@ spec:
     - port: 6443
       protocol: TCP
   ingress: []
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Now that we use `cilium` as our CNI, the network policies that rely on `ipBlock` won't work. We need to add a `ciliumnetworkpolicy` instead.

---

## Checklist

- [X] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
