### PR TITLE
Allow using AWS external connection from any provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow using AWS Route53 from any provider [#200](https://github.com/giantswarm/external-dns-app/pull/200)
+
 ## [2.17.0] - 2022-11-10
 
 ### Added

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: IfNotPresent
         env:
-        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "vmware")) .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+        {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (or (eq .Values.provider "aws") (eq .Values.provider "vmware")) .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+{{ if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR allows enabling aws usage from any provider.

Towards https://github.com/giantswarm/giantswarm/issues/24533

---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
