### PR TITLE
Add: capa provider for irsa service account annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
+- CAPA provider for service account `irsa` annotation
+
+### Added
+
 - Support for running behind a proxy.
   - `HTTP_PROXY`,`HTTPS_PROXY` and `NO_PROXY` are set as environment variables in the deployment if defined in `values.yaml`.
 - Support for using `cluster-apps-operator` specific `cluster.proxy` values.

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{- if and (eq .Values.provider "aws") (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
+  {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
   {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}


### PR DESCRIPTION
This PR adds the following:
- `capa` provider for `irsa` service account annotation

Issue: https://github.com/giantswarm/roadmap/issues/1640



---

## Checklist

- [x] Added a CHANGELOG entry