### PR TITLE
Align serviceaccount to upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - ServiceAccount: Align to upstream ([#207](https://github.com/giantswarm/external-dns-app/pull/207)).
-  - Helper: Add upstream helpers helpers.
+  - Helper: Add upstream helpers.
   - ServiceAccount: Add annotations from values.
 
 ## [2.19.0] - 2022-11-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- ServiceAccount: Align to upstream ([]()).
+  - Helper: Add upstream helpers helpers.
+  - ServiceAccount: Add annotations from values.
+
 ## [2.19.0] - 2022-11-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- ServiceAccount: Align to upstream ([]()).
+- ServiceAccount: Align to upstream ([#207](https://github.com/giantswarm/external-dns-app/pull/207)).
   - Helper: Add upstream helpers helpers.
   - ServiceAccount: Add annotations from values.
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -201,10 +201,23 @@ external-dns: aws.zoneType
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Upstream chart helpers.
+*/}}
+
+{{/*
+Common labels
+Temporarly include labels.common during the alignment to upstream.
+*/}}
+{{- define "external-dns.labels" -}}
+{{ include "labels.common" . }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Unless there is a override, we use the release name as the full name.
 */}}
 {{- define "external-dns.fullname" -}}
 {{- if .Values.fullnameOverride }}

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -200,3 +200,27 @@ external-dns: aws.zoneType
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "external-dns.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "external-dns.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "external-dns.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         prometheus.io/scrape: "{{ .Values.global.metrics.scrape }}"
         kubectl.kubernetes.io/default-container: "{{ .Release.Name }}"
     spec:
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ include "external-dns.serviceAccountName" . }}
       securityContext:
         runAsUser: {{ .Values.global.securityContext.userID }}
         runAsGroup: {{ .Values.global.securityContext.groupID }}

--- a/helm/external-dns-app/templates/rbac.yaml
+++ b/helm/external-dns-app/templates/rbac.yaml
@@ -61,5 +61,5 @@ roleRef:
   name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ include "external-dns.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "external-dns.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -1,14 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "external-dns.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
-  {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
-  annotations:
-    giantswarm.io/gcp-service-account: 'external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
-  {{- end }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
+    {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
+    giantswarm.io/gcp-service-account: 'external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -6,13 +6,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
+  {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
+    giantswarm.io/gcp-service-account: 'external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-    {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
-    {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
-    giantswarm.io/gcp-service-account: 'external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
-    {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -7,20 +7,12 @@ metadata:
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
   {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template "aws.iam.role" . }}"
-    {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- $_ := set .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" (tpl "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template \"aws.iam.role\" . }}" .) }}
   {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
-    giantswarm.io/gcp-service-account: 'external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
-    {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- else }}
+  {{- $_ := set .Values.serviceAccount.annotations "giantswarm.io/gcp-service-account" (tpl "external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com" .) }}
+  {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -246,7 +246,7 @@
         "provider": {
             "type": "string"
         },
-         "proxy": {
+        "proxy": {
             "type": "object",
             "properties": {
                 "http": {
@@ -257,6 +257,20 @@
                 },
                 "noProxy": {
                     "type": ["null", "string"]
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -198,6 +198,15 @@ crd:
       cpu: 500m
       memory: 512Mi
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 global:
 
   # global.image


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:
- Add upstream helpers for name generation.
- Align serviceaccount.yaml to upstream and add respective values
- update schemas
- Add labels helper
- update changelog

Towards https://github.com/giantswarm/roadmap/issues/411

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
