### PR TITLE
align deployment labels annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Compose role rules based on values.
   - Rename ClusterRoleBinding.
   - Enable RBAC creation based on values.
+- Deployment: Align to upstream ([#210](https://github.com/giantswarm/external-dns-app/pull/210))
+  - Add annotations from values
+  - Add labels in pods from values
+  - Add annotations in pods from values
 
 ## [2.19.0] - 2022-11-18
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -202,6 +202,22 @@ external-dns: aws.zoneType
 {{- end -}}
 
 
+
+{{/*
+Set Giant Swarm podAnnotations.
+*/}}
+{{- define "giantswarm.podAnnotations" -}}
+{{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
+{{- $_ := set .Values.podAnnotations "iam.amazonaws.com/role" (tpl "{{ template \"aws.iam.role\" . }}" .) }}
+{{- end }}
+{{- $_ := set .Values.podAnnotations "scheduler.alpha.kubernetes.io/critical-pod" "" }}
+{{- $_ := set .Values.podAnnotations "prometheus.io/path" "/metrics" }}
+{{- $_ := set .Values.podAnnotations "prometheus.io/port" (tpl "{{ .Values.global.metrics.port }}" .) }}
+{{- $_ := set .Values.podAnnotations "prometheus.io/scrape" (tpl "{{ .Values.global.metrics.scrape }}" .) }}
+{{- $_ := set .Values.podAnnotations "kubectl.kubernetes.io/default-container" (tpl "{{ .Release.Name }}" .)}}
+{{- end -}}
+
+
 {{/*
 Upstream chart helpers.
 */}}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/monitoring_basic_sli: "true"
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -21,15 +25,14 @@ spec:
         {{- if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
         giantswarm.io/gcp-workload-identity: enabled
         {{- end }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "giantswarm.podAnnotations" . }}
+      {{- with .Values.podAnnotations }}
       annotations:
-        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-        iam.amazonaws.com/role: {{ template "aws.iam.role" . }}
-        {{- end }}
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        prometheus.io/path: /metrics
-        prometheus.io/port: "{{ .Values.global.metrics.port }}"
-        prometheus.io/scrape: "{{ .Values.global.metrics.scrape }}"
-        kubectl.kubernetes.io/default-container: "{{ .Release.Name }}"
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "external-dns.serviceAccountName" . }}
       securityContext:

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -116,6 +116,9 @@
                 }
             }
         },
+        "deploymentAnnotations": {
+            "type": "object"
+        },
         "e2e": {
             "type": "boolean"
         },
@@ -242,6 +245,12 @@
                     }
                 }
             }
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podLabels": {
+            "type": "object"
         },
         "provider": {
             "type": "string"

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -211,6 +211,14 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
   additionalPermissions: []
+ 
+# Annotations to add to the Deployment
+deploymentAnnotations: {}
+
+podLabels: {}
+
+# Annotations to add to the Pod
+podAnnotations: {}
 
 sources:
   - service

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -211,7 +211,7 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
   additionalPermissions: []
- 
+
 # Annotations to add to the Deployment
 deploymentAnnotations: {}
 


### PR DESCRIPTION


<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:
- Add new values for deployment's annotations and labels
- Add helper for GS podAnnotations
- Template annotations and labels in deployment from values
- update schemas
- update changelog

Towards https://github.com/giantswarm/roadmap/issues/411

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
