### PR TITLE
extra volumes and envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## Added
+
+- Deployment: Align to upstream ([#212](https://github.com/giantswarm/external-dns-app/pull/212)).
+  - Add extraVolumes and extraVolumeMounts from values.
+  - Add environment variables from values.
+  - Add secretConfiguration for injecting secrets to deployment.
+
 ## [2.20.0] - 2022-12-05
 
 ### Changed
@@ -15,15 +22,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Helper: Add upstream helpers.
   - ServiceAccount: Add annotations from values.
 - RBAC: Align to upstream ([#209](https://github.com/giantswarm/external-dns-app/pull/209))
-  - Split rbac.yaml into clusterrole.yaml and clusterrolebinding.yaml
+  - Split rbac.yaml into clusterrole.yaml and clusterrolebinding.yaml.
   - Compose role rules based on values.
   - Rename ClusterRoleBinding.
   - Enable RBAC creation based on values.
-- Deployment: Align to upstream ([#210](https://github.com/giantswarm/external-dns-app/pull/210) [#211](https://github.com/giantswarm/external-dns-app/pull/211))
-  - Add annotations from values
-  - Add labels in pods from values
-  - Add annotations in pods from values
-  - Add deployment specs
+- Deployment: Align to upstream ([#210](https://github.com/giantswarm/external-dns-app/pull/210) [#211](https://github.com/giantswarm/external-dns-app/pull/211)).
+  - Add annotations from values.
+  - Add labels in pods from values.
+  - Add annotations in pods from values.
+  - Add deployment specs.
 
 ## [2.19.0] - 2022-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## Added
 
-- Deployment: Align to upstream ([#212](https://github.com/giantswarm/external-dns-app/pull/212)).
+- Deployment: Align to upstream ([#214](https://github.com/giantswarm/external-dns-app/pull/214)).
   - Add extraVolumes and extraVolumeMounts from values.
   - Add environment variables from values.
   - Add secretConfiguration for injecting secrets to deployment.

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -102,35 +102,38 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: IfNotPresent
         env:
-        {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-route53-credentials
-              key: aws_access_key_id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-route53-credentials
-              key: aws_secret_access_key
-        {{- end }}
-        {{- with .Values.aws.region }}
-        - name: AWS_DEFAULT_REGION
-          value: {{ . }}
-        {{- end }}
-        {{- if and $proxy.noProxy $proxy.http $proxy.https }}
-        - name: NO_PROXY
-          value: {{ $proxy.noProxy }}
-        - name: no_proxy
-          value: {{ $proxy.noProxy }}
-        - name: HTTP_PROXY
-          value: {{ $proxy.http }}
-        - name: http_proxy
-          value: {{ $proxy.http }}
-        - name: HTTPS_PROXY
-          value: {{ $proxy.https }}
-        - name: https_proxy
-          value: {{ $proxy.https }}
+          {{- with .Values.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-route53-credentials
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-route53-credentials
+                key: aws_secret_access_key
+          {{- end }}
+          {{- with .Values.aws.region }}
+          - name: AWS_DEFAULT_REGION
+            value: {{ . }}
+          {{- end }}
+          {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+          - name: NO_PROXY
+            value: {{ $proxy.noProxy }}
+          - name: no_proxy
+            value: {{ $proxy.noProxy }}
+          - name: HTTP_PROXY
+            value: {{ $proxy.http }}
+          - name: http_proxy
+            value: {{ $proxy.http }}
+          - name: HTTPS_PROXY
+            value: {{ $proxy.https }}
+          - name: https_proxy
+            value: {{ $proxy.https }}
           {{- end }}
         args:
         {{- if .Values.externalDNS.dryRun }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -181,15 +181,36 @@ spec:
         - name: metrics
           containerPort: {{ .Values.global.metrics.port }}
           protocol: TCP
-      {{- if eq .Values.provider "azure" }}
+        {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
         volumeMounts:
-        - name: config
-          mountPath: /config
-          readOnly: true
+          {{- if eq .Values.provider "azure" }}
+          - name: config
+            mountPath: /config
+            readOnly: true
+          {{- end }}
+          {{- if .Values.secretConfiguration.enabled }}
+          - name: secrets
+            mountPath: {{ tpl .Values.secretConfiguration.mountPath $ }}
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes (eq .Values.provider "azure") }}
       volumes:
-      - name: config
-        emptyDir: {}
-      - name: etc-kubernetes
-        hostPath:
-          path: /etc/kubernetes
+        {{- if eq .Values.provider "azure" }}
+        - name: config
+          emptyDir: {}
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        {{- end }}
+        {{- if .Values.secretConfiguration.enabled }}
+        - name: secrets
+          secret:
+            secretName: {{ include "external-dns.fullname" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -125,6 +125,9 @@
         "e2e": {
             "type": "boolean"
         },
+        "env": {
+            "type": "array"
+        },
         "externalDNS": {
             "type": "object",
             "properties": {
@@ -177,6 +180,12 @@
                     }
                 }
             }
+        },
+        "extraVolumeMounts": {
+            "type": "array"
+        },
+        "extraVolumes": {
+            "type": "array"
         },
         "gcpProject": {
             "type": "string"
@@ -286,6 +295,20 @@
                 },
                 "create": {
                     "type": "boolean"
+                }
+            }
+        },
+        "secretConfiguration": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "mountPath": {
+                    "type": "string"
                 }
             }
         },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -230,6 +230,8 @@ dnsPolicy:
 
 priorityClassName: "giantswarm-critical"
 
+env: []
+
 terminationGracePeriodSeconds:
 
 sources:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -232,12 +232,21 @@ priorityClassName: "giantswarm-critical"
 
 env: []
 
+extraVolumes: []
+
+extraVolumeMounts: []
+
 terminationGracePeriodSeconds:
 
 sources:
   - service
   - ingress
   - crd
+
+secretConfiguration:
+  enabled: false
+  mountPath: /.aws/credentials
+  data: {}
 
 global:
 


### PR DESCRIPTION

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Add env variables from values
- Add extraVolumes, extraVolumeMounts and secretConfiguration
- Add changelog

Towards https://github.com/giantswarm/roadmap/issues/411

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works

