### PR TITLE
Add IRSA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 .pytest_cache
 test_results_*.xml
+
+rendered/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add pre-unstall,pre-upgrade helm hook that sets up ServiceAccount for IRSA
+- Add pre-unstall,pre-upgrade helm hook that sets up ServiceAccount for IRSA and add helm value to enable it
 
 ## [2.21.0] - 2022-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add pre-unstall,pre-upgrade helm hook that sets up ServiceAccount for IRSA
+
 ## [2.21.0] - 2022-12-08
 
 ## Added

--- a/helm/external-dns-app/files/serviceaccount.yaml
+++ b/helm/external-dns-app/files/serviceaccount.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "external-dns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+  {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") }}
+  {{- $_ := set .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" (tpl "arn:aws:iam::<<AWS_ACCOUNT_ID>>:role/{{ template \"aws.iam.role\" . }}" .) }}
+  {{- else if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
+  {{- $_ := set .Values.serviceAccount.annotations "giantswarm.io/gcp-service-account" (tpl "external-dns-app@{{ .Values.gcpProject }}.iam.gserviceaccount.com" .) }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -35,6 +35,14 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{/*
+Service account install annotations.
+*/}}
+{{- define "annotations.serviceaccount" -}}
+helm.sh/hook: pre-install,pre-upgrade
+helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{- end -}}
+
+{{/*
 Create the list of domains to update
 */}}
 {{- define "domain.list" }}

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -39,6 +39,6 @@ spec:
   - 'emptyDir'
   - 'hostPath'
   {{- end }}
-  {{- if eq .Values.provider "gcp" }}
+  {{- if has .Values.provider (list "gcp" "capa") }}
   - 'projected'
   {{- end }}

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if or .Values.serviceAccount.create .Values.serviceAccount.useIRSA }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if not .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/configmap.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/configmap.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.useIRSA }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/configmap.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-serviceaccount-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "annotations.serviceaccount" . | nindent 4 }}
+    helm.sh/hook-weight: "-5"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: serviceaccount-install
+data:
+  serviceaccount.yaml: |
+{{ tpl ( .Files.Get "files/serviceaccount.yaml" ) . | indent 4 }}
+{{- end }}
+

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -47,3 +47,4 @@ spec:
           name: {{ .Release.Name }}-serviceaccount-install
       restartPolicy: Never
   backoffLimit: 4
+{{- end }}

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: kubectl
         securityContext:
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         image: {{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2
         command:
         - sh

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.create }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -35,7 +35,7 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
 
-          {{- if and .Values.serviceAccount.create (or (eq .Values.provider "aws") (eq .Values.provider "capa")) }}
+          {{- if and (not .Values.serviceAccount.create) (or (eq .Values.provider "aws") (eq .Values.provider "capa")) }}
           export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
           sed "s/<<AWS_ACCOUNT_ID>>/$ACCOUNT_ID/g" files/serviceaccount.yaml | kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=-
           {{ else }}

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "external-dns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "annotations.crd" . | nindent 4 }}
+    helm.sh/hook-weight: "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: serviceaccount-install
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "labels.common" . | nindent 8 }}
+        app.kubernetes.io/component: serviceaccount-install
+    spec:
+      serviceAccountName: {{ .Release.Name }}-serviceaccount-install
+      securityContext:
+        runAsUser: {{ .Values.global.securityContext.userID }}
+        runAsGroup: {{ .Values.global.securityContext.groupID }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kubectl
+        securityContext:
+          readOnlyRootFilesystem: false
+        image: {{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2
+        command:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
+
+          sed "s/<<AWS_ACCOUNT_ID>>/$ACCOUNT_ID/g" files/serviceaccountdyaml | kubectl apply --sedver-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=-
+        volumeMounts:
+        - name: {{ .Release.Name }}-serviceaccount-install
+          mountPath: /files
+      volumes:
+      - name: {{ .Release.Name }}-serviceaccount-install
+        configMap:
+          name: {{ .Release.Name }}-serviceaccount-install
+      restartPolicy: Never
+  backoffLimit: 4

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -37,9 +37,11 @@ spec:
 
           {{- if and .Values.serviceAccount.create (or (eq .Values.provider "aws") (eq .Values.provider "capa")) }}
           export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
+          sed "s/<<AWS_ACCOUNT_ID>>/$ACCOUNT_ID/g" files/serviceaccount.yaml | kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=-
+          {{ else }}
+          kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=files/serviceaccount.yaml
           {{- end }}
 
-          sed "s/<<AWS_ACCOUNT_ID>>/$ACCOUNT_ID/g" files/serviceaccount.yaml | kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=-
         volumeMounts:
         - name: {{ .Release.Name }}-serviceaccount-install
           mountPath: /files

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.useIRSA }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -41,6 +41,7 @@ spec:
         volumeMounts:
         - name: {{ .Release.Name }}-serviceaccount-install
           mountPath: /files
+        resources: {{- toYaml .Values.serviceAccount.resources | nindent 10 }}
       volumes:
       - name: {{ .Release.Name }}-serviceaccount-install
         configMap:

--- a/helm/external-dns-app/templates/serviceaccount/job.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/job.yaml
@@ -35,9 +35,11 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
 
+          {{- if and .Values.serviceAccount.create (or (eq .Values.provider "aws") (eq .Values.provider "capa")) }}
           export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
+          {{- end }}
 
-          sed "s/<<AWS_ACCOUNT_ID>>/$ACCOUNT_ID/g" files/serviceaccountdyaml | kubectl apply --sedver-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=-
+          sed "s/<<AWS_ACCOUNT_ID>>/$ACCOUNT_ID/g" files/serviceaccount.yaml | kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename=-
         volumeMounts:
         - name: {{ .Release.Name }}-serviceaccount-install
           mountPath: /files

--- a/helm/external-dns-app/templates/serviceaccount/rbac.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.useIRSA }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/rbac.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/rbac.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-serviceaccount-install
+  annotations:
+    {{- include "annotations.serviceaccount" . | nindent 4 }}
+    helm.sh/hook-weight: "-3"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: serviceaccount-install
+rules:
+- apiGroups: [""]
+  resources:
+  - serviceaccounts
+  verbs:
+  - use
+  - get
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-serviceaccount-install
+  annotations:
+    {{- include "annotations.serviceaccount" . | nindent 4 }}
+    helm.sh/hook-weight: "-2"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: serviceaccount-install
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-serviceaccount-install
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-serviceaccount-install
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/external-dns-app/templates/serviceaccount/rbac.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-serviceaccount-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "annotations.serviceaccount" . | nindent 4 }}
+    helm.sh/hook-weight: "-4"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: serviceaccount-install
+{{- end }}
+

--- a/helm/external-dns-app/templates/serviceaccount/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/external-dns-app/templates/serviceaccount/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/serviceaccount/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.create }}
+{{- if not .Values.serviceAccount.useIRSA }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -323,6 +323,36 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "useIRSA": {
+                    "type": "boolean"
                 }
             }
         },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -209,6 +209,21 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+  #Needed for the creation of an irsa suppoerted service account
+  resources:
+
+    # crd.resources.requests
+    # Minimum resources requested for the job.
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+    # crd.resources.limits
+    # Maximum resources available for the job.
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -203,6 +203,10 @@ imagePullSecrets: []
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Specifies whether to use IRSA. This option is incompatible with
+  # `create=false` as the ServiceAccount will be created by a
+  # pre-install,pre-upgrade hook.
+  useIRSA: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -209,7 +209,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-  #Needed for the creation of an irsa suppoerted service account
+  # Needed for the creation of an irsa suppoerted service account
   resources:
 
     # crd.resources.requests


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:
Adds a pre-install and pre-upgrade hook that creates the ServiceAccount. This is necessary because the job needs to get the AWS account ID and set it in the annotation.

Issue - https://github.com/giantswarm/roadmap/issues/1640


---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
