### PR TITLE
add nodeSelector affinity, topologySpreadContraints, and tolerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Added projected volumes for `capa`
+- Add nodeSelector, affinity, topologySpreadContraints and tolerations values to align to upstream ([223](https://github.com/giantswarm/external-dns-app/pull/223))
 
 ### Changed 
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -230,4 +230,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -214,3 +214,20 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "affinity": {
+            "type": "object"
+        },
         "aws": {
             "type": "object",
             "properties": {
@@ -261,6 +264,9 @@
         "imagePullSecrets": {
             "type": "array"
         },
+        "nodeSelector": {
+            "type": "object"
+        },
         "podAnnotations": {
             "type": "object"
         },
@@ -340,6 +346,12 @@
         },
         "terminationGracePeriodSeconds": {
             "type": ["null", "integer"]
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "topologySpreadConstraints": {
+            "type": "array"
         }
     }
 }

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -236,6 +236,14 @@ extraVolumes: []
 
 extraVolumeMounts: []
 
+tolerations: []
+
+nodeSelector: {}
+
+affinity: {}
+
+topologySpreadConstraints: []
+
 terminationGracePeriodSeconds:
 
 sources:
@@ -326,3 +334,4 @@ baseDomain: gigantic.io
 # from the default-catalog. It is dynamically set and will be overridden. Specific
 # to Giant Swarm clusters.
 clusterID: en2jo
+

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -336,4 +336,3 @@ baseDomain: gigantic.io
 # from the default-catalog. It is dynamically set and will be overridden. Specific
 # to Giant Swarm clusters.
 clusterID: en2jo
-


### PR DESCRIPTION


<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- add nodeSelector, affinity, topologySpreadContraints and tolerations
- edit values.schema

In reference to https://github.com/giantswarm/giantswarm/issues/25032



---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
