### PR TITLE
Align deployment args to upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+<<<<<<< HEAD
 - Service account `irsa` annotation for `aws` and `capa` to align with `aws-pod-identity-webhook-app` changes
-- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227) [#229](https://github.com/giantswarm/external-dns-app/pull/229)).
+- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227) [#229](https://github.com/giantswarm/external-dns-app/pull/229) [#224](https://github.com/giantswarm/external-dns-app/pull/224)).
   - Template deployment strategy from values
   - Align indentation
   - Move blocks to match upstream structure
@@ -18,6 +19,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Take imagePullPolicy from values
   - Add secret's mount subpath
   - Take securityContext from values
+  - Add new arguments for logging and events
 
 ## [2.22.0] - 2023-01-02
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -144,6 +144,11 @@ spec:
               value: {{ $proxy.https }}
             {{- end }}
           args:
+            - --log-level={{ .Values.logLevel }}
+            - --log-format={{ .Values.logFormat }}
+            {{- if .Values.triggerLoopOnEvent }}
+            - --events
+            {{- end }}
             {{- if .Values.externalDNS.dryRun }}
             - --dry-run
             {{- end }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -275,6 +275,12 @@
         "imagePullSecrets": {
             "type": "array"
         },
+        "logFormat": {
+            "type": "string"
+        },
+        "logLevel": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },
@@ -394,6 +400,9 @@
         },
         "topologySpreadConstraints": {
             "type": "array"
+        },
+        "triggerLoopOnEvent": {
+            "type": "boolean"
         }
     }
 }

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -253,6 +253,11 @@ affinity: {}
 
 topologySpreadConstraints: []
 
+logLevel: info
+logFormat: text
+
+triggerLoopOnEvent: false
+
 terminationGracePeriodSeconds:
 
 sources:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

Adds new arguments taken from upstream.

Towards https://github.com/giantswarm/giantswarm/issues/25032

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
