### PR TITLE
Align labels with upstream

### DIFF
--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -6,24 +6,11 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Common labels
+Giantswarm labels
 */}}
-{{- define "labels.common" -}}
-{{ include "labels.selector" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/name: {{ .Release.Name | quote }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- define "giantswarm.labels" -}}
 giantswarm.io/service-type: "{{ .Values.serviceType }}"
-helm.sh/chart: {{ include "chart" . | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
-{{- end -}}
-
-{{/*
-Selector labels
-*/}}
-{{- define "labels.selector" -}}
-app: {{ .Release.Name | quote }}
 {{- end -}}
 
 {{/*

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -230,6 +230,8 @@ Common labels
 */}}
 {{- define "external-dns.labels" -}}
 helm.sh/chart: {{ include "external-dns.chart" . }}
+app.kubernetes.io/name: {{ include "external-dns.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "external-dns.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -245,8 +247,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "external-dns.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "external-dns.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app: {{ .Release.Name | quote }}
 {{- end }}
 
 {{/*

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -219,6 +219,13 @@ Upstream chart helpers.
 */}}
 
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "external-dns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "external-dns.labels" -}}

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -1,9 +1,9 @@
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "external-dns.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Common labels

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -214,18 +214,33 @@ Set Giant Swarm serviceAccountAnnotations.
 {{- end }}
 {{- end -}}
 
-
 {{/*
 Upstream chart helpers.
 */}}
 
 {{/*
 Common labels
-Temporarly include labels.common during the alignment to upstream.
 */}}
 {{- define "external-dns.labels" -}}
-{{ include "labels.common" . }}
+helm.sh/chart: {{ include "external-dns.chart" . }}
+{{ include "external-dns.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{ include "giantswarm.labels" . }}
 {{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "external-dns.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "external-dns.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.

--- a/helm/external-dns-app/templates/crd/configmap.yaml
+++ b/helm/external-dns-app/templates/crd/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-5"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 data:
   dnsendpoints.yaml: |

--- a/helm/external-dns-app/templates/crd/job.yaml
+++ b/helm/external-dns-app/templates/crd/job.yaml
@@ -8,13 +8,13 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-1"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 spec:
   template:
     metadata:
       labels:
-        {{- include "labels.common" . | nindent 8 }}
+        {{- include "external-dns.labels" . | nindent 8 }}
         app.kubernetes.io/component: crd-install
     spec:
       serviceAccountName: {{ .Release.Name }}-crd-install

--- a/helm/external-dns-app/templates/crd/np.yaml
+++ b/helm/external-dns-app/templates/crd/np.yaml
@@ -10,12 +10,12 @@ metadata:
     "helm.sh/hook-weight": "-7"
     {{- include "annotations.crd" . | nindent 4 }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 spec:
   endpointSelector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "external-dns.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: crd-install
   egress:
     - toEntities:
@@ -35,12 +35,12 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-7"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 spec:
   podSelector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "external-dns.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: crd-install
   policyTypes:
   - Egress

--- a/helm/external-dns-app/templates/crd/psp.yaml
+++ b/helm/external-dns-app/templates/crd/psp.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-6"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 spec:
   privileged: false

--- a/helm/external-dns-app/templates/crd/rbac.yaml
+++ b/helm/external-dns-app/templates/crd/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-3"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 rules:
 - apiGroups:
@@ -34,7 +34,7 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-2"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/external-dns-app/templates/crd/serviceaccount.yaml
+++ b/helm/external-dns-app/templates/crd/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "annotations.crd" . | nindent 4 }}
     helm.sh/hook-weight: "-4"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     app.kubernetes.io/component: crd-install
 {{- end }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     giantswarm.io/monitoring_basic_sli: "true"
   {{- with .Values.deploymentAnnotations }}
   annotations:
@@ -15,13 +15,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "external-dns.selectorLabels" . | nindent 6 }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        {{- include "labels.common" . | nindent 8 }}
+        {{- include "external-dns.labels" . | nindent 8 }}
         {{- if and (eq .Values.provider "gcp") (.Values.gcpProject) }}
         giantswarm.io/gcp-workload-identity: enabled
         {{- end }}

--- a/helm/external-dns-app/templates/metrics-service.yaml
+++ b/helm/external-dns-app/templates/metrics-service.yaml
@@ -8,7 +8,7 @@ metadata:
     giantswarm.io/monitoring-port: {{ .Values.global.metrics.port | quote }}
     giantswarm.io/monitoring-app-label: {{ .Chart.Name | quote }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
 spec:
   clusterIP: None
@@ -17,4 +17,4 @@ spec:
     port: {{ .Values.global.metrics.port }}
     targetPort: metrics
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    {{- include "external-dns.selectorLabels" . | nindent 4 }}

--- a/helm/external-dns-app/templates/np.yaml
+++ b/helm/external-dns-app/templates/np.yaml
@@ -4,11 +4,11 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "external-dns.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Ingress
   - Egress

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -3,7 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ .Release.Name }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
 spec:
   fsGroup:
     rule: 'MustRunAs'

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ .Release.Name }}-route53-credentials"
   namespace: "{{ .Release.Namespace }}"
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
 data:
   aws_access_key_id: {{ .Values.externalDNS.aws_access_key_id | b64enc }}
   aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}

--- a/helm/external-dns-app/templates/vpa.yaml
+++ b/helm/external-dns-app/templates/vpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "labels.common" . | nindent 4 }}
+    {{- include "external-dns.labels" . | nindent 4 }}
 spec:
   resourcePolicy:
     containerPolicies:


### PR DESCRIPTION


<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:
- align chart template
- Rename labels.common and remove old labels.selector
- Align external-dns.labels to upstream and define selectorLabels template
- Include external-dns.labels and selectorLabels in templates

https://github.com/giantswarm/giantswarm/issues/25032

---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
