### PR TITLE
Align deployment indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed 
+
+- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227)).
+  - Template deployment strategy from values
+  - Align indentation
+
 ## [2.22.0] - 2023-01-02
 
 ### Added

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -178,9 +178,9 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 1
         ports:
-        - name: metrics
-          containerPort: {{ .Values.global.metrics.port }}
-          protocol: TCP
+          - name: metrics
+            containerPort: {{ .Values.global.metrics.port }}
+            protocol: TCP
         {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
         volumeMounts:
           {{- if eq .Values.provider "azure" }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -136,31 +136,31 @@ spec:
             value: {{ $proxy.https }}
           {{- end }}
         args:
-        {{- if .Values.externalDNS.dryRun }}
-        - --dry-run
-        {{- end }}
-        {{- range .Values.externalDNS.sources }}
-        - --source={{ . }}
-        {{- end }}
-        - --policy={{ .Values.externalDNS.policy }}
-        - --annotation-filter={{- template "annotation.filter" . }}
-        {{- if .Values.externalDNS.interval }}
-        - --interval={{ .Values.externalDNS.interval }}
-        {{- end }}
-        {{- include "dnsProvider.flags" . | nindent 8 }}
-        - --metrics-address=:{{ .Values.global.metrics.port }}
-        {{- if .Values.externalDNS.namespaceFilter }}
-        - --namespace={{ .Values.externalDNS.namespaceFilter }}
-        {{- end }}
-        {{- if .Values.externalDNS.minEventSyncInterval }}
-        - --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
-        {{- end }}
-        - --registry=txt
-        - --txt-owner-id={{- template "txt.owner.id" . }}
-        - --txt-prefix={{- template "txt.prefix" . }}
-      {{- range .Values.externalDNS.extraArgs }}
-        - {{ . }}
-      {{- end }}
+          {{- if .Values.externalDNS.dryRun }}
+          - --dry-run
+          {{- end }}
+          {{- range .Values.externalDNS.sources }}
+          - --source={{ . }}
+          {{- end }}
+          - --policy={{ .Values.externalDNS.policy }}
+          - --annotation-filter={{- template "annotation.filter" . }}
+          {{- if .Values.externalDNS.interval }}
+          - --interval={{ .Values.externalDNS.interval }}
+          {{- end }}
+          {{- include "dnsProvider.flags" . | nindent 10 }}
+          - --metrics-address=:{{ .Values.global.metrics.port }}
+          {{- if .Values.externalDNS.namespaceFilter }}
+          - --namespace={{ .Values.externalDNS.namespaceFilter }}
+          {{- end }}
+          {{- if .Values.externalDNS.minEventSyncInterval }}
+          - --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
+          {{- end }}
+          - --registry=txt
+          - --txt-owner-id={{- template "txt.owner.id" . }}
+          - --txt-prefix={{- template "txt.prefix" . }}
+          {{- range .Values.externalDNS.extraArgs }}
+          - {{ . }}
+          {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
         readinessProbe:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -98,104 +98,104 @@ spec:
           resources:
             {{- toYaml .Values.global.resources | nindent 12 }}
         {{- end }}
-      - name: {{ .Release.Name }}
-        image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
-        imagePullPolicy: IfNotPresent
-        env:
-          {{- with .Values.env }}
-          {{- toYaml . | nindent 10 }}
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-route53-credentials
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-route53-credentials
+                  key: aws_secret_access_key
+            {{- end }}
+            {{- with .Values.aws.region }}
+            - name: AWS_DEFAULT_REGION
+              value: {{ . }}
+            {{- end }}
+            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+            - name: NO_PROXY
+              value: {{ $proxy.noProxy }}
+            - name: no_proxy
+              value: {{ $proxy.noProxy }}
+            - name: HTTP_PROXY
+              value: {{ $proxy.http }}
+            - name: http_proxy
+              value: {{ $proxy.http }}
+            - name: HTTPS_PROXY
+              value: {{ $proxy.https }}
+            - name: https_proxy
+              value: {{ $proxy.https }}
+            {{- end }}
+          args:
+            {{- if .Values.externalDNS.dryRun }}
+            - --dry-run
+            {{- end }}
+            {{- range .Values.externalDNS.sources }}
+            - --source={{ . }}
+            {{- end }}
+            - --policy={{ .Values.externalDNS.policy }}
+            - --annotation-filter={{- template "annotation.filter" . }}
+            {{- if .Values.externalDNS.interval }}
+            - --interval={{ .Values.externalDNS.interval }}
+            {{- end }}
+            {{- include "dnsProvider.flags" . | nindent 12 }}
+            - --metrics-address=:{{ .Values.global.metrics.port }}
+            {{- if .Values.externalDNS.namespaceFilter }}
+            - --namespace={{ .Values.externalDNS.namespaceFilter }}
+            {{- end }}
+            {{- if .Values.externalDNS.minEventSyncInterval }}
+            - --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
+            {{- end }}
+            - --registry=txt
+            - --txt-owner-id={{- template "txt.owner.id" . }}
+            - --txt-prefix={{- template "txt.prefix" . }}
+            {{- range .Values.externalDNS.extraArgs }}
+            - {{ . }}
+            {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.metrics.port }}
+              scheme: HTTP
+          resources:
+            {{- toYaml .Values.global.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.metrics.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.global.metrics.port }}
+              protocol: TCP
+          {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
+          volumeMounts:
+            {{- if eq .Values.provider "azure" }}
+            - name: config
+              mountPath: /config
+              readOnly: true
+            {{- end }}
+            {{- if .Values.secretConfiguration.enabled }}
+            - name: secrets
+              mountPath: {{ tpl .Values.secretConfiguration.mountPath $ }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-          {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Release.Name }}-route53-credentials
-                key: aws_access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Release.Name }}-route53-credentials
-                key: aws_secret_access_key
-          {{- end }}
-          {{- with .Values.aws.region }}
-          - name: AWS_DEFAULT_REGION
-            value: {{ . }}
-          {{- end }}
-          {{- if and $proxy.noProxy $proxy.http $proxy.https }}
-          - name: NO_PROXY
-            value: {{ $proxy.noProxy }}
-          - name: no_proxy
-            value: {{ $proxy.noProxy }}
-          - name: HTTP_PROXY
-            value: {{ $proxy.http }}
-          - name: http_proxy
-            value: {{ $proxy.http }}
-          - name: HTTPS_PROXY
-            value: {{ $proxy.https }}
-          - name: https_proxy
-            value: {{ $proxy.https }}
-          {{- end }}
-        args:
-          {{- if .Values.externalDNS.dryRun }}
-          - --dry-run
-          {{- end }}
-          {{- range .Values.externalDNS.sources }}
-          - --source={{ . }}
-          {{- end }}
-          - --policy={{ .Values.externalDNS.policy }}
-          - --annotation-filter={{- template "annotation.filter" . }}
-          {{- if .Values.externalDNS.interval }}
-          - --interval={{ .Values.externalDNS.interval }}
-          {{- end }}
-          {{- include "dnsProvider.flags" . | nindent 10 }}
-          - --metrics-address=:{{ .Values.global.metrics.port }}
-          {{- if .Values.externalDNS.namespaceFilter }}
-          - --namespace={{ .Values.externalDNS.namespaceFilter }}
-          {{- end }}
-          {{- if .Values.externalDNS.minEventSyncInterval }}
-          - --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
-          {{- end }}
-          - --registry=txt
-          - --txt-owner-id={{- template "txt.owner.id" . }}
-          - --txt-prefix={{- template "txt.prefix" . }}
-          {{- range .Values.externalDNS.extraArgs }}
-          - {{ . }}
-          {{- end }}
-        securityContext:
-          readOnlyRootFilesystem: true
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: {{ .Values.global.metrics.port }}
-            scheme: HTTP
-        resources:
-{{ toYaml .Values.global.resources | indent 10 }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: {{ .Values.global.metrics.port }}
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-        ports:
-          - name: metrics
-            containerPort: {{ .Values.global.metrics.port }}
-            protocol: TCP
-        {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
-        volumeMounts:
-          {{- if eq .Values.provider "azure" }}
-          - name: config
-            mountPath: /config
-            readOnly: true
-          {{- end }}
-          {{- if .Values.secretConfiguration.enabled }}
-          - name: secrets
-            mountPath: {{ tpl .Values.secretConfiguration.mountPath $ }}
-          {{- end }}
-          {{- with .Values.extraVolumeMounts }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- end }}
       {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes (eq .Values.provider "azure") }}
       volumes:
         {{- if eq .Values.provider "azure" }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -64,27 +64,27 @@ spec:
           - -c
           - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
         {{- end }}
-      {{- if eq .Values.provider "azure" }}
-      - name: copy-azure-config-file
-        image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3
-        command:
-          - /bin/sh
-          - -c
-          # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
-          # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
-          - if [ -f /etc/kubernetes/config/azure.yaml ];
-            then
-            cp /etc/kubernetes/config/azure.yaml /config/azure.yaml;
-            else
-            cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml;
-            fi
-        volumeMounts:
-          - mountPath: /etc/kubernetes
-            name: etc-kubernetes
-            readOnly: true
-          - mountPath: /config
-            name: config
-      {{- end }}
+        {{- if eq .Values.provider "azure" }}
+        - name: copy-azure-config-file
+          image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3
+          command:
+            - /bin/sh
+            - -c
+            # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
+            # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
+            - if [ -f /etc/kubernetes/config/azure.yaml ];
+              then
+              cp /etc/kubernetes/config/azure.yaml /config/azure.yaml;
+              else
+              cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml;
+              fi
+          volumeMounts:
+            - mountPath: /etc/kubernetes
+              name: etc-kubernetes
+              readOnly: true
+            - mountPath: /config
+              name: config
+        {{- end }}
       containers:
       {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
       - name: "{{ .Release.Name }}-check-iam"

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -86,18 +86,18 @@ spec:
               name: config
         {{- end }}
       containers:
-      {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-      - name: "{{ .Release.Name }}-check-iam"
-        image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
-        command:
-        - /bin/sh
-        - -c
-        - while wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep -q {{ template "aws.iam.role" . }} ; do sleep 30 ; done && exit 1
-        securityContext:
-          readOnlyRootFilesystem: true
-        resources:
-{{ toYaml .Values.global.resources | indent 10 }}
-      {{- end }}
+        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
+        - name: "{{ .Release.Name }}-check-iam"
+          image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
+          command:
+          - /bin/sh
+          - -c
+          - while wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep -q {{ template "aws.iam.role" . }} ; do sleep 30 ; done && exit 1
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            {{- toYaml .Values.global.resources | nindent 12 }}
+        {{- end }}
       - name: {{ .Release.Name }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: IfNotPresent

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -56,14 +56,14 @@ spec:
       dnsPolicy: {{ . }}
       {{- end }}
       initContainers:
-      {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-      - name: wait-for-iam-role
-        image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
-        command:
-        - /bin/sh
-        - -c
-        - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
-      {{- end }}
+        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
+        - name: wait-for-iam-role
+          image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
+          command:
+          - /bin/sh
+          - -c
+          - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
+        {{- end }}
       {{- if eq .Values.provider "azure" }}
       - name: copy-azure-config-file
         image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     matchLabels:
       {{- include "external-dns.selectorLabels" . | nindent 6 }}
   strategy:
-    type: Recreate
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "external-dns.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -122,6 +122,14 @@
         "deploymentAnnotations": {
             "type": "object"
         },
+        "deploymentStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "dnsPolicy": {
             "type": ["null","string"]
         },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -258,6 +258,9 @@ secretConfiguration:
   mountPath: /.aws/credentials
   data: {}
 
+deploymentStrategy:
+  type: Recreate
+
 global:
 
   # global.image


### PR DESCRIPTION

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Replace deploy name with `include`
- Template deployment strategy from values
- Indent aws init container
- Indent azure init container
- Indent check-iam container
- Indent args in main container
- Indent ports in main container
- Indent main container

Towards https://github.com/giantswarm/giantswarm/issues/25032

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
