### PR TITLE
align deploy template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed 
 
-- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227)).
+- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227) [#228](https://github.com/giantswarm/external-dns-app/pull/228)).
   - Template deployment strategy from values
   - Align indentation
+  - Move blocks to match upstream structure
+  - Add annotations for secret reload
+  - Take imagePullPolicy from values
+  - Add secret's mount subpath
+
 
 ## [2.22.0] - 2023-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add annotations for secret reload
   - Take imagePullPolicy from values
   - Add secret's mount subpath
-
+  - Take securityContext from values
 
 ## [2.22.0] - 2023-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed 
 
-- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227) [#228](https://github.com/giantswarm/external-dns-app/pull/228)).
+- Deployment: Align to upstream ([#227](https://github.com/giantswarm/external-dns-app/pull/227) [#229](https://github.com/giantswarm/external-dns-app/pull/229)).
   - Template deployment strategy from values
   - Align indentation
   - Move blocks to match upstream structure

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -28,10 +28,14 @@ spec:
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- include "giantswarm.podAnnotations" . }}
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.secretConfiguration.enabled .Values.podAnnotations }}
       annotations:
+        {{- if .Values.secretConfiguration.enabled }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -98,9 +102,13 @@ spec:
           resources:
             {{- toYaml .Values.global.resources | nindent 12 }}
         {{- end }}
-        - name: {{ .Release.Name }}
+        - name: external-dns
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           env:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -161,15 +169,10 @@ spec:
             {{- range .Values.externalDNS.extraArgs }}
             - {{ . }}
             {{- end }}
-          securityContext:
-            readOnlyRootFilesystem: true
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.global.metrics.port }}
-              scheme: HTTP
-          resources:
-            {{- toYaml .Values.global.resources | nindent 12 }}
+          ports:
+            - name: metrics
+              protocol: TCP
+              containerPort: {{ .Values.global.metrics.port }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -177,10 +180,11 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
-          ports:
-            - name: metrics
-              containerPort: {{ .Values.global.metrics.port }}
-              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.metrics.port }}
+              scheme: HTTP
           {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
           volumeMounts:
             {{- if eq .Values.provider "azure" }}
@@ -191,11 +195,16 @@ spec:
             {{- if .Values.secretConfiguration.enabled }}
             - name: secrets
               mountPath: {{ tpl .Values.secretConfiguration.mountPath $ }}
+            {{- with .Values.secretConfiguration.subPath }}
+              subPath: {{ tpl . $ }}
+            {{- end }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+          resources:
+            {{- toYaml .Values.global.resources | nindent 12 }}
       {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes (eq .Values.provider "azure") }}
       volumes:
         {{- if eq .Values.provider "azure" }}

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -332,6 +332,31 @@
                 }
             }
         },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
         "serviceAccount": {
             "type": "object",
             "properties": {

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -210,6 +210,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
                         "registry": {
                             "type": "string"
                         },
@@ -322,6 +325,9 @@
                     "type": "boolean"
                 },
                 "mountPath": {
+                    "type": "string"
+                },
+                "subPath": {
                     "type": "string"
                 }
             }

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -256,6 +256,7 @@ sources:
 secretConfiguration:
   enabled: false
   mountPath: /.aws/credentials
+  subPath: ""
   data: {}
 
 deploymentStrategy:
@@ -276,6 +277,7 @@ global:
     # global.image.tag
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync.
     tag: v0.11.0
+    pullPolicy: IfNotPresent
 
   # global.metrics
   # Metrics configuration options

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -226,6 +226,13 @@ podAnnotations: {}
 
 shareProcessNamespace: false
 
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
 # Defaults to `ClusterFirst`.
 # Valid values are: `ClusterFirstWithHostNet`, `ClusterFirst`, `Default` or `None`.
 dnsPolicy:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Align deployment to upstream
    - Move blocks to match upstream structure
    - Add annotations for secret reload
    - Take imagePullPolicy from values
    - Add secret's mount subpath
    - Take securityContext from values
- update schemas
- Update changelog

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
