### PR TITLE
add support for CAPZ based management clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support to run in `hostNetwork` (primary used in `CAPZ` based management clusters)
+
 ## [2.23.2] - 2023-01-17
 
 ### Fixed

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
         runAsUser: {{ .Values.global.securityContext.userID }}
         runAsGroup: {{ .Values.global.securityContext.groupID }}
         fsGroup: {{ .Values.global.securityContext.fsGroupID }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -11,7 +11,12 @@ spec:
       - min: {{ .Values.global.securityContext.fsGroupID }}
         max: {{ .Values.global.securityContext.fsGroupID }}
   hostIPC: false
-  hostNetwork: false
+  {{- if .Values.hostNetwork }}
+  hostNetwork: true
+  hostPorts:
+  - min: {{ .Values.global.metrics.port }}
+    max: {{ .Values.global.metrics.port }}
+  {{- end }}
   hostPID: false
   privileged: false
   readOnlyRootFilesystem: false

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -272,6 +272,9 @@
                 }
             }
         },
+        "hostNetwork": {
+            "type": "boolean"
+        },
         "imagePullSecrets": {
             "type": "array"
         },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -325,6 +325,9 @@ global:
     # global.securityContext.userID
     userID: 65534
 
+# hostNetwork
+hostNetwork: false
+
 # provider
 # Identifies the cloud provider. Currently supported: `aws` and `azure`. This *must*
 # be set. If this is installed as a default app from the default-catalog then this


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

* prepares `external-dns` to make it run on `CAPZ` based management clusters.
* the required configuration changes can be seen in this `config` PR: https://github.com/giantswarm/config/pull/1610


## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
