### PR TITLE
Service: align to upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Replace `global.metrics.port` value with `service.port`.
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
+  - Move podAnnotations to values.
 
 ## [2.33.0] - 2023-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Service: Align to upstream ([#243](https://github.com/giantswarm/external-dns-app/pull/243)).
+  - Replace `global.metrics.port` value with `service.port`.
+  - Add service annotations with GS defaults.
+  - Set readinessProbe and livenessProbe from values.
+
 ## [2.33.0] - 2023-03-07
 
 ### Added

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -196,11 +196,6 @@ Set Giant Swarm podAnnotations.
 {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
 {{- $_ := set .Values.podAnnotations "iam.amazonaws.com/role" (tpl "{{ template \"aws.iam.role\" . }}" .) }}
 {{- end }}
-{{- $_ := set .Values.podAnnotations "scheduler.alpha.kubernetes.io/critical-pod" "" }}
-{{- $_ := set .Values.podAnnotations "prometheus.io/path" "/metrics" }}
-{{- $_ := set .Values.podAnnotations "prometheus.io/port" (tpl "{{ .Values.global.metrics.port }}" .) }}
-{{- $_ := set .Values.podAnnotations "prometheus.io/scrape" (tpl "{{ .Values.global.metrics.scrape }}" .) }}
-{{- $_ := set .Values.podAnnotations "kubectl.kubernetes.io/default-container" (tpl "{{ .Release.Name }}" .)}}
 {{- end -}}
 
 {{/*

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -165,7 +165,6 @@ spec:
             - --interval={{ .Values.externalDNS.interval }}
             {{- end }}
             {{- include "dnsProvider.flags" . | nindent 12 }}
-            - --metrics-address=:{{ .Values.global.metrics.port }}
             {{- if .Values.externalDNS.namespaceFilter }}
             - --namespace={{ .Values.externalDNS.namespaceFilter }}
             {{- end }}
@@ -179,9 +178,9 @@ spec:
             - {{ . }}
             {{- end }}
           ports:
-            - name: metrics
+            - name: http
               protocol: TCP
-              containerPort: {{ .Values.global.metrics.port }}
+              containerPort: 7979
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -183,17 +183,9 @@ spec:
               protocol: TCP
               containerPort: {{ .Values.global.metrics.port }}
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.global.metrics.port }}
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.global.metrics.port }}
-              scheme: HTTP
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
           volumeMounts:
             {{- if eq .Values.provider "azure" }}

--- a/helm/external-dns-app/templates/metrics-service.yaml
+++ b/helm/external-dns-app/templates/metrics-service.yaml
@@ -1,20 +1,21 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-monitoring
+  name: {{ include "external-dns.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: {{ .Values.global.metrics.port | quote }}
-    giantswarm.io/monitoring-app-label: {{ .Chart.Name | quote }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  clusterIP: None
-  ports:
-  - name: metrics
-    port: {{ .Values.global.metrics.port }}
-    targetPort: metrics
+  type: ClusterIP
   selector:
     {{- include "external-dns.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/helm/external-dns-app/templates/np.yaml
+++ b/helm/external-dns-app/templates/np.yaml
@@ -14,7 +14,7 @@ spec:
   - Egress
   ingress:
   - ports:
-    - port: {{ .Values.global.metrics.port }}
+    - port: {{ .Values.service.port }}
       protocol: TCP
   egress:
   - {}

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -14,8 +14,8 @@ spec:
   {{- if .Values.hostNetwork }}
   hostNetwork: true
   hostPorts:
-  - min: {{ .Values.global.metrics.port }}
-    max: {{ .Values.global.metrics.port }}
+  - min: {{ .Values.service.port }}
+    max: {{ .Values.service.port }}
   {{- end }}
   hostPID: false
   privileged: false

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -417,6 +417,17 @@
                 }
             }
         },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
         "serviceAccount": {
             "type": "object",
             "properties": {

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -221,17 +221,6 @@
                         }
                     }
                 },
-                "metrics": {
-                    "type": "object",
-                    "properties": {
-                        "port": {
-                            "type": "integer"
-                        },
-                        "scrape": {
-                            "type": "boolean"
-                        }
-                    }
-                },
                 "resources": {
                     "type": "object",
                     "properties": {
@@ -278,6 +267,37 @@
         "imagePullSecrets": {
             "type": "array"
         },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
         "logFormat": {
             "type": "string"
         },
@@ -321,6 +341,37 @@
                 },
                 "create": {
                     "type": "boolean"
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
                 }
             }
         },

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -323,18 +323,6 @@ global:
     tag: v0.11.0
     pullPolicy: IfNotPresent
 
-  # global.metrics
-  # Metrics configuration options
-  metrics:
-
-    # global.metrics.port
-    # The port to serve metrics on.
-    port: 7979
-
-    # global.metrics.scrape
-    # Enable/disable scraping by Prometheus.
-    scrape: true
-
   # global.resources
   # Set pod resource limits and requests. This is passed as a YAML
   # dictionary directly into the deployment manifest.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -226,7 +226,7 @@ podAnnotations:
   scheduler.alpha.kubernetes.io/critical-pod: ""
   prometheus.io/path: /metrics
   prometheus.io/port: "7979"
-  prometheus.io/scrape: true
+  prometheus.io/scrape: "true"
   kubectl.kubernetes.io/default-container: external-dns
 
 shareProcessNamespace: false

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -222,7 +222,12 @@ deploymentAnnotations: {}
 podLabels: {}
 
 # Annotations to add to the Pod
-podAnnotations: {}
+podAnnotations:
+  scheduler.alpha.kubernetes.io/critical-pod: ""
+  prometheus.io/path: /metrics
+  prometheus.io/port: 7979
+  prometheus.io/scrape: true
+  kubectl.kubernetes.io/default-container: external-dns
 
 shareProcessNamespace: false
 

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -265,7 +265,7 @@ service:
   port: 7979
   annotations:
     giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: 7979
+    giantswarm.io/monitoring-port: "7979"
     giantswarm.io/monitoring-app-label: "external-dns-app"
 
 extraVolumes: []

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -261,6 +261,13 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+service:
+  port: 7979
+  annotations:
+    giantswarm.io/monitoring-path: /metrics
+    giantswarm.io/monitoring-port: 7979
+    giantswarm.io/monitoring-app-label: "external-dns-app"
+
 extraVolumes: []
 
 extraVolumeMounts: []

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -241,6 +241,26 @@ priorityClassName: "giantswarm-critical"
 
 env: []
 
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
 extraVolumes: []
 
 extraVolumeMounts: []

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -225,7 +225,7 @@ podLabels: {}
 podAnnotations:
   scheduler.alpha.kubernetes.io/critical-pod: ""
   prometheus.io/path: /metrics
-  prometheus.io/port: 7979
+  prometheus.io/port: "7979"
   prometheus.io/scrape: true
   kubectl.kubernetes.io/default-container: external-dns
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25030

This PR:
- Service: Align to upstream
  - Replace `global.metrics.port` value with `service.port`.
  - Add service annotations with GS defaults.
  - Set readinessProbe and livenessProbe from values.

---

## Checklist

- [X] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
