### PR TITLE
set-crd-job-limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Configure request and limits for CRD job.
+
 ## [2.34.1] - 2023-03-22
 
 ### Added

--- a/helm/external-dns-app/templates/crd/job.yaml
+++ b/helm/external-dns-app/templates/crd/job.yaml
@@ -37,6 +37,8 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
           kubectl apply --server-side=true --field-manager='kubectl-client-side-apply' --force-conflicts --filename /crd 2>&1
+        resources:
+          {{- toYaml .Values.crd.resources | nindent 10 }}
         volumeMounts:
         - name: {{ .Release.Name }}-crd-install
           mountPath: /crd


### PR DESCRIPTION
limits on job were not rendered at all, that often resulted in OOM kill
```
    state:
      terminated:
        containerID: containerd://e47f432fde77b6215b7a4be02ed68772ee80bcdf8bec4bfc9df200ec51590c3f
        exitCode: 137
        finishedAt: "2023-03-23T13:10:32Z"
        reason: OOMKilled
        startedAt: "2023-03-23T13:10:23Z"
```