### PR TITLE
rename master as main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ workflows:
       - architect/run-tests-with-ats:
           name: execute chart tests
           filters:
-            # Do not trigger the job on merge to master.
+            # Do not trigger the job on merge to main.
             branches:
               ignore:
-                - master
+                - main
           requires:
             - "package and push to default catalog"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ External DNS is Apache 2.0 licensed and accepts contributions via GitHub pull re
 ## Getting started
 
 - Fork the repository on GitHub
-- Read the [README.md](https://github.com/giantswarm/example-opensource-repo/blob/master/README.md) for build instructions
+- Read the [README.md](https://github.com/giantswarm/example-opensource-repo/blob/main/README.md) for build instructions
 
 ## Reporting Bugs and Creating Issues
 
@@ -36,7 +36,7 @@ We might ask you for further information to locate a bug. A duplicated bug repor
 
 This is a rough outline of what a contributor's workflow looks like:
 
-- Create a feature branch from where you want to base your work. This is usually master.
+- Create a feature branch from where you want to base your work. This is usually main.
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ External DNS is Apache 2.0 licensed and accepts contributions via GitHub pull re
 ## Getting started
 
 - Fork the repository on GitHub
-- Read the [README.md](https://github.com/giantswarm/example-opensource-repo/blob/main/README.md) for build instructions
+- Read the [README.md](https://github.com/giantswarm/example-opensource-repo/blob/master/README.md) for build instructions
 
 ## Reporting Bugs and Creating Issues
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ There are 3 ways to install this app onto a workload cluster:
 
 ## Configuring
 
-Configuration options are documented in the [Configuration.md](https://github.com/giantswarm/external-dns-app/blob/master/helm/external-dns-app/Configuration.md)
-document. See also the [default `values.yaml`](https://github.com/giantswarm/external-dns-app/blob/master/helm/external-dns-app/values.yaml)
+Configuration options are documented in the [Configuration.md](https://github.com/giantswarm/external-dns-app/blob/main/helm/external-dns-app/Configuration.md)
+document. See also the [default `values.yaml`](https://github.com/giantswarm/external-dns-app/blob/main/helm/external-dns-app/values.yaml)
 
 ### values.yaml
 
@@ -118,7 +118,7 @@ Not following these limitations will most likely result in a broken deployment.
 
 External DNS v2.0.0+ requires
 * Kubernetes version `1.19.0-0` or greater
-* [nginx-ingress-controller-app v1.14.0](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#1140---2021-02-03) or greater to work (due to the need for the filtering annotation).
+* [nginx-ingress-controller-app v1.14.0](https://github.com/giantswarm/nginx-ingress-controller-app/blob/main/CHANGELOG.md#1140---2021-02-03) or greater to work (due to the need for the filtering annotation).
   * If you do not (or cannot) upgrade `nginx-ingress-controller-app` to `v1.14.0`,
     you can work around this by running the following command to ensure the default
     `external-dns` continues to reconcile the relevant Service:
@@ -131,7 +131,7 @@ kubectl -n kube-system annotate service nginx-ingress-controller-app "giantswarm
 
 * Ensure CHANGELOG.md is up to date.
 * Create a new branch to trigger the release workflow e.g. to release `v0.1.0`,
-create a branch from master called `master#release#v0.1.0` and push it.
+create a branch from main called `main#release#v0.1.0` and push it.
 * This will push a new git tag and trigger a new tarball to be pushed to the
 `default-catalog` and the `giantswarm-catalog`
 


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
