### PR TITLE
Create secrets from secretConfiguration values OR AWS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Create secret from `secretConfiguration.data` value without breaking AWS Credentials values compatibility.
+
 ## [2.35.0] - 2023-04-04
 
 ### Changed

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+{{ if or .Values.secretConfiguration.enabled (and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +7,13 @@ metadata:
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 data:
+  {{ if .Values.externalDNS.aws_access_key_id }}
   aws_access_key_id: {{ .Values.externalDNS.aws_access_key_id | b64enc }}
+  {{- end }}
+  {{ if .Values.externalDNS.aws_secret_access_key }}
   aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}
-type: Opaque
-{{ end -}}
+  {{- end }}
+{{- range $key, $value := .Values.secretConfiguration.data }}
+  {{ $key }}: {{ tpl $value $ | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if or .Values.secretConfiguration.enabled (and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key) }}
+{{ if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,12 +7,20 @@ metadata:
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 data:
-  {{ if .Values.externalDNS.aws_access_key_id }}
   aws_access_key_id: {{ .Values.externalDNS.aws_access_key_id | b64enc }}
-  {{- end }}
-  {{ if .Values.externalDNS.aws_secret_access_key }}
   aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}
-  {{- end }}
+type: Opaque
+---
+{{ end -}}
+{{- if .Values.secretConfiguration.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "external-dns.labels" . | nindent 4 }}
+data:
 {{- range $key, $value := .Values.secretConfiguration.data }}
   {{ $key }}: {{ tpl $value $ | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR: 
- Create secret from either secretConfigurations or AWS credentials. This is a transitional step towards removing dedicated aws credential values.

We need this intermediate step to facilitate upgrade path. Towards https://github.com/giantswarm/giantswarm/issues/26448 and https://github.com/giantswarm/giantswarm/issues/25029

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
