### PR TITLE
Move initContainers and env to helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Move initContainers and env into a helper function [#259](https://github.com/giantswarm/external-dns-app/pull/259).
+
 ## [2.35.1] - 2023-04-14
 
 ### Changed

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -217,6 +217,43 @@ Set Giant Swarm serviceAccountAnnotations.
 {{- end -}}
 
 {{/*
+Set Giant Swarm env for Deployment.
+*/}}
+{{- define "giantswarm.deploymentEnv" -}}
+{{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+  secretKeyRef:
+    name: {{ .Release.Name }}-route53-credentials
+    key: aws_access_key_id
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+  secretKeyRef:
+    name: {{ .Release.Name }}-route53-credentials
+    key: aws_secret_access_key
+{{- end }}
+{{- with .Values.aws.region }}
+- name: AWS_DEFAULT_REGION
+  value: {{ . }}
+{{- end }}
+{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy -}}
+{{- if and $proxy.noProxy $proxy.http $proxy.https }}
+- name: NO_PROXY
+  value: {{ $proxy.noProxy }}
+- name: no_proxy
+  value: {{ $proxy.noProxy }}
+- name: HTTP_PROXY
+  value: {{ $proxy.http }}
+- name: http_proxy
+  value: {{ $proxy.http }}
+- name: HTTPS_PROXY
+  value: {{ $proxy.https }}
+- name: https_proxy
+  value: {{ $proxy.https }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Upstream chart helpers.
 */}}
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -254,6 +254,40 @@ Set Giant Swarm env for Deployment.
 {{- end -}}
 
 {{/*
+Set Giant Swarm initContainers.
+*/}}
+{{- define "giantswarm.deploymentInitContainers" -}}
+{{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
+- name: wait-for-iam-role
+  image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
+  command:
+    - /bin/sh
+    - -c
+    - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
+{{- end }}
+{{- if eq .Values.provider "azure" }}
+- name: copy-azure-config-file
+  image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3
+  command:
+    - /bin/sh
+    - -c
+    # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
+    # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
+    - if [ -f /etc/kubernetes/config/azure.yaml ]; then
+      cp /etc/kubernetes/config/azure.yaml /config/azure.yaml;
+      else
+      cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml;
+      fi
+  volumeMounts:
+    - mountPath: /etc/kubernetes
+      name: etc-kubernetes
+      readOnly: true
+    - mountPath: /config
+      name: config
+{{- end }}
+{{- end -}}
+
+{{/*
 Upstream chart helpers.
 */}}
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -63,35 +63,7 @@ spec:
       dnsPolicy: {{ . }}
       {{- end }}
       initContainers:
-        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-        - name: wait-for-iam-role
-          image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
-          command:
-          - /bin/sh
-          - -c
-          - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
-        {{- end }}
-        {{- if eq .Values.provider "azure" }}
-        - name: copy-azure-config-file
-          image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3
-          command:
-            - /bin/sh
-            - -c
-            # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
-            # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
-            - if [ -f /etc/kubernetes/config/azure.yaml ];
-              then
-              cp /etc/kubernetes/config/azure.yaml /config/azure.yaml;
-              else
-              cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml;
-              fi
-          volumeMounts:
-            - mountPath: /etc/kubernetes
-              name: etc-kubernetes
-              readOnly: true
-            - mountPath: /config
-              name: config
-        {{- end }}
+        {{- include "giantswarm.deploymentInitContainers" . | nindent 8 }}
       containers:
         {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
         - name: "{{ .Release.Name }}-check-iam"

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -117,36 +116,7 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-route53-credentials
-                  key: aws_access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-route53-credentials
-                  key: aws_secret_access_key
-            {{- end }}
-            {{- with .Values.aws.region }}
-            - name: AWS_DEFAULT_REGION
-              value: {{ . }}
-            {{- end }}
-            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
-            - name: NO_PROXY
-              value: {{ $proxy.noProxy }}
-            - name: no_proxy
-              value: {{ $proxy.noProxy }}
-            - name: HTTP_PROXY
-              value: {{ $proxy.http }}
-            - name: http_proxy
-              value: {{ $proxy.http }}
-            - name: HTTPS_PROXY
-              value: {{ $proxy.https }}
-            - name: https_proxy
-              value: {{ $proxy.https }}
-            {{- end }}
+            {{- include "giantswarm.deploymentEnv" . | nindent 12 }}
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This is more a cosmetic change, therefore goes to current main 

This PR:
- move GS env variables to a helper function
- move initContainers to helper function

Towards https://github.com/giantswarm/giantswarm/issues/25235


---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
