### PR TITLE
- Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [2.35.0] - 2023-04-04
 
 ### Changed

--- a/helm/external-dns-app/templates/crd/psp.yaml
+++ b/helm/external-dns-app/templates/crd/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 {{- if .Values.crd.install }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -32,4 +33,5 @@ spec:
     - min: 1
       max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -47,3 +48,4 @@ spec:
   {{- if has .Values.provider (list "gcp" "capa") }}
   - 'projected'
   {{- end }}
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25