### PR TITLE
Remove aws credentials values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
   - Move podAnnotations to values.
+- Secrets: Remove deprecated values for AWS Route53 external authentication []().
 
 ## [2.37.0] - 2023-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
   - Move podAnnotations to values.
-- Secrets: Remove deprecated values for AWS Route53 external authentication []().
+- Secrets: Remove deprecated values for AWS Route53 external authentication [#266](https://github.com/giantswarm/external-dns-app/pull/266).
 
 ## [2.37.0] - 2023-05-04
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -215,22 +215,6 @@ Set Giant Swarm serviceAccountAnnotations.
 Set Giant Swarm env for Deployment.
 */}}
 {{- define "giantswarm.deploymentEnv" -}}
-{{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-- name: AWS_ACCESS_KEY_ID
-  valueFrom:
-  secretKeyRef:
-    name: {{ .Release.Name }}-route53-credentials
-    key: aws_access_key_id
-- name: AWS_SECRET_ACCESS_KEY
-  valueFrom:
-  secretKeyRef:
-    name: {{ .Release.Name }}-route53-credentials
-    key: aws_secret_access_key
-{{- end }}
-{{- with .Values.aws.region }}
-- name: AWS_DEFAULT_REGION
-  value: {{ . }}
-{{- end }}
 {{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy -}}
 {{- if and $proxy.noProxy $proxy.http $proxy.https }}
 - name: NO_PROXY

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,17 +1,3 @@
-{{ if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{ .Release.Name }}-route53-credentials"
-  namespace: "{{ .Release.Namespace }}"
-  labels:
-    {{- include "external-dns.labels" . | nindent 4 }}
-data:
-  aws_access_key_id: {{ .Values.externalDNS.aws_access_key_id | b64enc }}
-  aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}
-type: Opaque
----
-{{ end -}}
 {{- if .Values.secretConfiguration.enabled }}
 apiVersion: v1
 kind: Secret

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -84,14 +84,6 @@ externalDNS:
   # instances of external-dns.
   annotationFilter: "giantswarm.io/external-dns=managed"
 
-  # externalDNS.aws_access_key_id
-  # Access key ID for the AWS API. Only required when aws.access is 'external'.
-  aws_access_key_id:
-
-  # externalDNS.aws_secret_access_key
-  # Access key secret for the AWS API. Only required when aws.access is 'external'.
-  aws_secret_access_key:
-
   # externalDNS.domainFilterList
   # One or more domains that this instance of external-dns will manage. If
   # no domains are provided then the cluster baseDomain must be provided via


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

Removes aws_access_key_id and aws_secret_access_key in favor of secretConfiguration & env values.

Towards https://github.com/giantswarm/giantswarm/issues/25029

Note this is merged into **main-v3**

---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
