### PR TITLE
fix env vars indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Remove deprecated annotation from Pod.[#265](https://github.com/giantswarm/external-dns-app/pull/265).
 
+### Fixed
+
+- Fix indentation in environment variables for secret injection [#272](https://github.com/giantswarm/external-dns-app/pull/272).
+
 ## [2.37.0] - 2023-05-04
 
 ### Changed

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -222,14 +222,14 @@ Set Giant Swarm env for Deployment.
 {{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
-  secretKeyRef:
-    name: {{ .Release.Name }}-route53-credentials
-    key: aws_access_key_id
+    secretKeyRef:
+      name: {{ .Release.Name }}-route53-credentials
+      key: aws_access_key_id
 - name: AWS_SECRET_ACCESS_KEY
   valueFrom:
-  secretKeyRef:
-    name: {{ .Release.Name }}-route53-credentials
-    key: aws_secret_access_key
+    secretKeyRef:
+      name: {{ .Release.Name }}-route53-credentials
+      key: aws_secret_access_key
 {{- end }}
 {{- with .Values.aws.region }}
 - name: AWS_DEFAULT_REGION


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

Towards https://github.com/giantswarm/roadmap/issues/2574



---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
