### PR TITLE
Docs: Rename `nginx-ingress-controller-app` to `ingress-nginx`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It can be installed multiple times in the same Workload Cluster.
 
 **Why did we add it?**
 
-The App is already used as a default App in most clusters (except on-prem) to provide DNS records for [nginx-ingress-controller-app](https://github.com/giantswarm/nginx-ingress-controller-app).
+The App is already used as a default App in most clusters (except on-prem) to provide DNS records for [Ingress NGINX Controller](https://github.com/giantswarm/ingress-nginx-app).
 
 **Who can use it?**
 
@@ -118,7 +118,7 @@ Not following these limitations will most likely result in a broken deployment.
 
 External DNS v2.0.0+ requires
 * Kubernetes version `1.19.0-0` or greater
-* [nginx-ingress-controller-app v1.14.0](https://github.com/giantswarm/nginx-ingress-controller-app/blob/main/CHANGELOG.md#1140---2021-02-03) or greater to work (due to the need for the filtering annotation).
+* [nginx-ingress-controller-app v1.14.0](https://github.com/giantswarm/ingress-nginx-app/blob/main/CHANGELOG.md#1140---2021-02-03) or greater to work (due to the need for the filtering annotation).
   * If you do not (or cannot) upgrade `nginx-ingress-controller-app` to `v1.14.0`,
     you can work around this by running the following command to ensure the default
     `external-dns` continues to reconcile the relevant Service:


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
