### PR TITLE
remove hardcoded references to vmware as they are no longer needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Hardcoded references to `provider==vmware` ([]()).
+
 ## [2.37.1] - 2023-06-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Removed
 
-- Hardcoded references to `provider==vmware` ([]()).
+- Hardcoded references to `provider==vmware` ([#277](https://github.com/giantswarm/external-dns-app/pull/277)).
 
 ## [2.37.1] - 2023-06-15
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -107,15 +107,11 @@ from the default catalog and is therefore a default app */}}
 {{- end -}}
 
 {{/*
-Set provider specific flags (VMWare clusters use Route53 for DNS). Ternary
-function returns `aws` if provider is vmware; otherwise it returns
-the value of .Values.provider.
+Set provider specific flags. 
 */}}
 {{- define "dnsProvider.flags" -}}
 {{- $dnsProvider := .Values.provider -}}
-{{- if eq .Values.provider "vmware" }}
-{{- $dnsProvider = "aws" -}}
-{{- else if eq .Values.provider "capa" }}
+{{- if eq .Values.provider "capa" }}
 {{- $dnsProvider = "aws" -}}
 {{- else if eq .Values.provider "gcp" }}
 {{- $dnsProvider = "google" -}}
@@ -134,10 +130,6 @@ the value of .Values.provider.
 - --aws-batch-change-interval={{ .Values.aws.batchChangeInterval }}
 {{- end }}
 {{ include "domain.list" . }}
-{{- end }}
-
-{{- if eq .Values.provider "vmware" }}
-- --source=crd
 {{- end }}
 
 {{- if eq .Values.provider "azure" }}
@@ -172,9 +164,9 @@ Validate that the provider makes sense
 don't expose that value to the user in the error message.
 */}}
 {{- define "validateValues.provider" -}}
-{{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "capa") (ne .Values.provider "gcp") (ne .Values.provider "vmware") (ne .Values.provider "inmemory") -}}
+{{- if and (ne .Values.provider "aws") (ne .Values.provider "azure") (ne .Values.provider "capa") (ne .Values.provider "gcp") (ne .Values.provider "inmemory") -}}
 external-dns: provider
-    Incorrect value provided. Valid values are either 'aws', 'azure', 'capa', 'gcp' or 'vmware'.
+    Incorrect value provided. Valid values are either 'aws', 'azure', 'capa' or 'gcp'.
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

https://github.com/giantswarm/giantswarm/issues/27482

---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
