### PR TITLE
Remove support for KIAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
   - Move podAnnotations to values.
-- Remove support for KIAM ([#278](https://github.com/giantswarm/external-dns-app/pull/278)).
 
 ### Removed
 
@@ -33,6 +32,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Remove dedicated option for `min-event-sync-interval` and set it in extraArgs.
   - Remove `externalDNS.dryRun` option.
 - Secrets: Remove deprecated values for AWS Route53 external authentication [#266](https://github.com/giantswarm/external-dns-app/pull/266).
+- Remove support for KIAM ([#278](https://github.com/giantswarm/external-dns-app/pull/278)).
+- Remove `aws.iam.customRoleName` value ([#278](https://github.com/giantswarm/external-dns-app/pull/278)).
 
 ## [2.37.1] - 2023-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
   - Move podAnnotations to values.
+- Remove support for KIAM ([#278](https://github.com/giantswarm/external-dns-app/pull/278)).
 
 ### Removed
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -47,12 +47,8 @@ Set the zone type when running on AWS
 Set the role name for IRSA
 */}}
 {{- define "aws.iam.role" -}}
-{{- if .Values.aws.iam.customRoleName }}
-{{- printf "%s" .Values.aws.iam.customRoleName }}
-{{- else }}
 {{- if eq .Values.aws.access "internal" }}
 {{- printf "%s-Route53Manager-Role" .Values.clusterID }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -27,7 +27,6 @@ spec:
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- include "giantswarm.podAnnotations" . }}
       {{- if or .Values.secretConfiguration.enabled .Values.podAnnotations }}
       annotations:
         {{- if .Values.secretConfiguration.enabled }}
@@ -65,20 +64,6 @@ spec:
       initContainers:
         {{- include "giantswarm.deploymentInitContainers" . | nindent 8 }}
       containers:
-        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-        - name: "{{ .Release.Name }}-check-iam"
-          image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2
-          command:
-          - /bin/sh
-          - -c
-          - while wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep -q {{ template "aws.iam.role" . }} ; do sleep 30 ; done && exit 1
-          securityContext:
-            readOnlyRootFilesystem: true
-          {{- with .Values.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        {{- end }}
         - name: external-dns
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -34,11 +34,6 @@ aws:
   # be used.
   batchChangeInterval: 10s
 
-  # aws.irsa
-  # Set to true when IAM roles for service accounts is enabled.
-  # It is dynamically set and will be overridden.
-  irsa: "false"
-
   # aws.zonesCacheDuration
   # Set the zones list cache TTL. If left blank then the default will
   # be used.

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -39,16 +39,6 @@ aws:
   # be used.
   zonesCacheDuration: 3h
 
-  # aws.iam
-  # AWS IAM configuration.
-  iam:
-
-    # aws.iam.customRole
-    # If set, allows a user-created role to be assumed. Role must have access to a
-    # policy which allows configuration of Route53 hosted zone(s).
-    # e.g. `customRoleName: route53-manager-role`
-    customRoleName:
-
   # aws.preferCNAME
   # Create CNAME records instead of ALIAS. Will always be set to true when aws.access
   # is `external`.


### PR DESCRIPTION

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:
Removes initContainer, custom podAnnotations and check-iam container. It also deprecates the `aws.irsa` value as it's the only option from now on.

Towards https://github.com/giantswarm/giantswarm/issues/26851

---

## Checklist

- [x] Added a CHANGELOG entry
