### PR TITLE
Add new values in preparation for v2->v3 transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Move CRD jobs into a separated subchart ([#275](https://github.com/giantswarm/external-dns-app/pull/275)).
+- Prepare new values for alignment ([]()).
+  - Add domainFilter and extraArgs values.
+  - Add interval, namepsaceFilter and minEventSyncInterval values.
+  - Add txtPrefix value with higher priority.
+  - Add txtOwnerId value with higher priority.
+  - Add annotationFilter value with higher priority.
 
 ### Removed
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -60,6 +60,9 @@ Set the role name for KIAM
 Set the annotation filter.
 */}}
 {{- define "annotation.filter" -}}
+{{- if .Values.annotationFilter -}}
+{{- printf "%s" .Values.annotationFilter }}
+{{- else }}
 {{- if .Values.NetExporter -}}
 {{/* if this value is present then the app was installed
 from the default catalog and is therefore a default app */}}
@@ -67,6 +70,7 @@ from the default catalog and is therefore a default app */}}
 {{- else -}}
 {{/* the customer must provide their own */}}
 {{- printf "%s" .Values.externalDNS.annotationFilter }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -78,6 +78,9 @@ from the default catalog and is therefore a default app */}}
 Set the txt owner ID.
 */}}
 {{- define "txt.owner.id" -}}
+{{- if .Values.txtOwnerId -}}
+{{- printf "%s" .Values.txtOwnerId }}
+{{- else }}
 {{- if .Values.NetExporter -}}
 {{/* if this value is present then the app was installed
 from the default catalog and is therefore a default app */}}
@@ -85,6 +88,7 @@ from the default catalog and is therefore a default app */}}
 {{- else -}}
 {{/* the customer must provide their own */}}
 {{- printf "%s" .Values.externalDNS.registry.txtOwnerID }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -96,6 +96,9 @@ from the default catalog and is therefore a default app */}}
 Set the txt record prefix.
 */}}
 {{- define "txt.prefix" -}}
+{{- if .Values.txtPrefix -}}
+{{- printf "%s" .Values.txtPrefix }}
+{{- else }}
 {{- if .Values.NetExporter -}}
 {{/* if this value is present then the app was installed
 from the default catalog and is therefore a default app */}}
@@ -103,6 +106,7 @@ from the default catalog and is therefore a default app */}}
 {{- else -}}
 {{/* the customer must provide their own */}}
 {{- printf "%s" .Values.externalDNS.registry.txtPrefix }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -111,9 +111,15 @@ spec:
             - --registry=txt
             - --txt-owner-id={{- template "txt.owner.id" . }}
             - --txt-prefix={{- template "txt.prefix" . }}
+            {{- range .Values.domainFilters }}
+            - --domain-filter={{ . }}
+            {{- end }}
             {{- range .Values.externalDNS.extraArgs }}
             - {{ . }}
             {{- end }}
+          {{- range .Values.extraArgs }}
+            - {{ tpl . $ }}
+          {{- end }}
           ports:
             - name: metrics
               protocol: TCP

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -92,6 +92,7 @@ spec:
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}
+            - --interval={{ default .Values.externalDNS.interval .Values.interval }}
             {{- if .Values.triggerLoopOnEvent }}
             - --events
             {{- end }}
@@ -103,17 +104,10 @@ spec:
             {{- end }}
             - --policy={{ .Values.externalDNS.policy }}
             - --annotation-filter={{- template "annotation.filter" . }}
-            {{- if .Values.externalDNS.interval }}
-            - --interval={{ .Values.externalDNS.interval }}
-            {{- end }}
             {{- include "dnsProvider.flags" . | nindent 12 }}
             - --metrics-address=:{{ .Values.global.metrics.port }}
-            {{- if .Values.externalDNS.namespaceFilter }}
-            - --namespace={{ .Values.externalDNS.namespaceFilter }}
-            {{- end }}
-            {{- if .Values.externalDNS.minEventSyncInterval }}
-            - --min-event-sync-interval={{ .Values.externalDNS.minEventSyncInterval }}
-            {{- end }}
+            - --namespace={{ default .Values.externalDNS.namespaceFilter .Values.namespaceFilter }}
+            - --min-event-sync-interval={{ default .Values.externalDNS.minEventSyncInterval .Values.minEventSyncInterval }}
             - --registry=txt
             - --txt-owner-id={{- template "txt.owner.id" . }}
             - --txt-prefix={{- template "txt.prefix" . }}


### PR DESCRIPTION


<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR allows the usage of new values to enable migration from v2 to v3.

- add annotationFilter value with higher priority
- add txtOwnerId value with higher priority
- add txtPrefix value with higher priority
- add interval, namepsaceFilter and minEventSyncInterval values
- add domainFilter and extraArgs values

Towards https://github.com/giantswarm/giantswarm/issues/27508

---

## Checklist

- [ ] Added a CHANGELOG entry