### PR TITLE
enable vendir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
   - Move podAnnotations to values.
+- Secrets: Remove deprecated values for AWS Route53 external authentication [#266](https://github.com/giantswarm/external-dns-app/pull/266).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,23 +16,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add txtPrefix value with higher priority.
   - Add txtOwnerId value with higher priority.
   - Add annotationFilter value with higher priority.
-
-### Removed
-
-- Hardcoded references to `provider==vmware` ([#277](https://github.com/giantswarm/external-dns-app/pull/277)).
-
-## [2.37.1] - 2023-06-15
-
-### Changed
-
-- Remove deprecated annotation from Pod.[#265](https://github.com/giantswarm/external-dns-app/pull/265).
 - Deployment: ALign to upstream ([#255](https://github.com/giantswarm/external-dns-app/pull/255)).
   - Use `crd.podSecurityContext` for crd job.
   - Rename `global.resources` as `resources`.
-  - Remove dedicated option for `min-event-sync-interval` and set it in extraArgs.
   - Rename `externalDNS.extraArgs` as `extraArgs`.
   - Rename `externalDNS.policy` as `policy`.
-  - Remove `externalDNS.dryRun` option.
   - Rename `externalDNS.sources` as `sources` and adjust default value.
   - Rename `externalDNS.interval` as `interval`.
   - Rename `global.image` as `image` using helper for name composition.
@@ -42,7 +30,20 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add service annotations with GS defaults.
   - Set readinessProbe and livenessProbe from values.
   - Move podAnnotations to values.
+
+### Removed
+
+- Hardcoded references to `provider==vmware` ([#277](https://github.com/giantswarm/external-dns-app/pull/277)).
+- Deployment: ALign to upstream ([#255](https://github.com/giantswarm/external-dns-app/pull/255)).
+  - Remove dedicated option for `min-event-sync-interval` and set it in extraArgs.
+  - Remove `externalDNS.dryRun` option.
 - Secrets: Remove deprecated values for AWS Route53 external authentication [#266](https://github.com/giantswarm/external-dns-app/pull/266).
+
+## [2.37.1] - 2023-06-15
+
+### Changed
+
+- Remove deprecated annotation from Pod.[#265](https://github.com/giantswarm/external-dns-app/pull/265).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Remove dedicated option for `min-event-sync-interval` and set it in extraArgs.
   - Remove `externalDNS.dryRun` option.
 - Secrets: Remove deprecated values for AWS Route53 external authentication [#266](https://github.com/giantswarm/external-dns-app/pull/266).
+- Remove support for KIAM ([#278](https://github.com/giantswarm/external-dns-app/pull/278)).
+- Remove `aws.iam.customRoleName` value ([#278](https://github.com/giantswarm/external-dns-app/pull/278)).
 
 ## [2.37.1] - 2023-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Remove deprecated annotation from Pod.[#265](https://github.com/giantswarm/external-dns-app/pull/265).
+- Deployment: ALign to upstream ([#255](https://github.com/giantswarm/external-dns-app/pull/255)).
+  - Use `crd.podSecurityContext` for crd job.
+  - Rename `global.resources` as `resources`.
+  - Remove dedicated option for `min-event-sync-interval` and set it in extraArgs.
+  - Rename `externalDNS.extraArgs` as `extraArgs`.
+  - Rename `externalDNS.policy` as `policy`.
+  - Remove `externalDNS.dryRun` option.
+  - Rename `externalDNS.sources` as `sources` and adjust default value.
+  - Rename `externalDNS.interval` as `interval`.
+  - Rename `global.image` as `image` using helper for name composition.
+  - Move `global.securityContext` to `podSecurityContext` and align names.
 - Service: Align to upstream ([#243](https://github.com/giantswarm/external-dns-app/pull/243)).
   - Replace `global.metrics.port` value with `service.port`.
   - Add service annotations with GS defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Remove deprecated annotation from Pod.[#265](https://github.com/giantswarm/external-dns-app/pull/265).
+- Service: Align to upstream ([#243](https://github.com/giantswarm/external-dns-app/pull/243)).
+  - Replace `global.metrics.port` value with `service.port`.
+  - Add service annotations with GS defaults.
+  - Set readinessProbe and livenessProbe from values.
+  - Move podAnnotations to values.
 
 ### Fixed
 

--- a/helm/external-dns-app/charts/crd/templates/job.yaml
+++ b/helm/external-dns-app/charts/crd/templates/job.yaml
@@ -28,7 +28,7 @@ spec:
       - name: kubectl
         securityContext:
           readOnlyRootFilesystem: true
-        image: {{ .Values.image.registry }}/giantswarm/docker-kubectl:1.24.2
+        image: {{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2
         command:
         - sh
         - -c

--- a/helm/external-dns-app/charts/crd/templates/job.yaml
+++ b/helm/external-dns-app/charts/crd/templates/job.yaml
@@ -15,9 +15,10 @@ spec:
         {{- include "crd.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-crd-install
+      {{- with .Values.crd.podSecurityContext }}
       securityContext:
-        runAsUser: {{ .Values.global.securityContext.userID }}
-        runAsGroup: {{ .Values.global.securityContext.groupID }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -27,7 +28,7 @@ spec:
       - name: kubectl
         securityContext:
           readOnlyRootFilesystem: true
-        image: {{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2
+        image: {{ .Values.image.registry }}/giantswarm/docker-kubectl:1.24.2
         command:
         - sh
         - -c

--- a/helm/external-dns-app/charts/crd/templates/job.yaml
+++ b/helm/external-dns-app/charts/crd/templates/job.yaml
@@ -15,7 +15,7 @@ spec:
         {{- include "crd.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-crd-install
-      {{- with .Values.crd.podSecurityContext }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/external-dns-app/charts/crd/values.yaml
+++ b/helm/external-dns-app/charts/crd/values.yaml
@@ -31,3 +31,7 @@ ciliumNetworkPolicy:
   enabled: true
 
 serviceType: "managed"
+
+podSecurityContext:
+  runAsGroup: 65534
+  runAsUser: 65534

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -192,10 +192,6 @@ Set Giant Swarm podAnnotations.
 {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
 {{- $_ := set .Values.podAnnotations "iam.amazonaws.com/role" (tpl "{{ template \"aws.iam.role\" . }}" .) }}
 {{- end }}
-{{- $_ := set .Values.podAnnotations "prometheus.io/path" "/metrics" }}
-{{- $_ := set .Values.podAnnotations "prometheus.io/port" (tpl "{{ .Values.global.metrics.port }}" .) }}
-{{- $_ := set .Values.podAnnotations "prometheus.io/scrape" (tpl "{{ .Values.global.metrics.scrape }}" .) }}
-{{- $_ := set .Values.podAnnotations "kubectl.kubernetes.io/default-container" (tpl "{{ .Release.Name }}" .)}}
 {{- end -}}
 
 {{/*

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -44,15 +44,11 @@ Set the zone type when running on AWS
 {{- end }}
 
 {{/*
-Set the role name for KIAM
+Set the role name for IRSA
 */}}
 {{- define "aws.iam.role" -}}
-{{- if .Values.aws.iam.customRoleName }}
-{{- printf "%s" .Values.aws.iam.customRoleName }}
-{{- else }}
 {{- if eq .Values.aws.access "internal" }}
 {{- printf "%s-Route53Manager-Role" .Values.clusterID }}
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -184,21 +180,11 @@ external-dns: aws.zoneType
 {{- end -}}
 {{- end -}}
 
-
-{{/*
-Set Giant Swarm podAnnotations.
-*/}}
-{{- define "giantswarm.podAnnotations" -}}
-{{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-{{- $_ := set .Values.podAnnotations "iam.amazonaws.com/role" (tpl "{{ template \"aws.iam.role\" . }}" .) }}
-{{- end }}
-{{- end -}}
-
 {{/*
 Set Giant Swarm serviceAccountAnnotations.
 */}}
 {{- define "giantswarm.serviceAccountAnnotations" -}}
-{{- if and (eq .Values.provider "aws") (eq .Values.aws.irsa "true") (eq .Values.aws.access "internal") (not (hasKey .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn")) }}
+{{- if and (eq .Values.provider "aws") (eq .Values.aws.access "internal") (not (hasKey .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn")) }}
 {{- $_ := set .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" (tpl "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ template \"aws.iam.role\" . }}" .) }}
 {{- else if and (eq .Values.provider "capa") (eq .Values.aws.access "internal") (not (hasKey .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn")) }}
 {{- $_ := set .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" (include "aws.iam.role" .) }}
@@ -232,14 +218,6 @@ Set Giant Swarm env for Deployment.
 Set Giant Swarm initContainers.
 */}}
 {{- define "giantswarm.deploymentInitContainers" -}}
-{{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-- name: wait-for-iam-role
-  image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2
-  command:
-    - /bin/sh
-    - -c
-    - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
-{{- end }}
 {{- if eq .Values.provider "azure" }}
 - name: copy-azure-config-file
   image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2-python3

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -211,22 +211,6 @@ Set Giant Swarm serviceAccountAnnotations.
 Set Giant Swarm env for Deployment.
 */}}
 {{- define "giantswarm.deploymentEnv" -}}
-{{- if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-- name: AWS_ACCESS_KEY_ID
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Release.Name }}-route53-credentials
-      key: aws_access_key_id
-- name: AWS_SECRET_ACCESS_KEY
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Release.Name }}-route53-credentials
-      key: aws_secret_access_key
-{{- end }}
-{{- with .Values.aws.region }}
-- name: AWS_DEFAULT_REGION
-  value: {{ . }}
-{{- end }}
 {{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy -}}
 {{- if and $proxy.noProxy $proxy.http $proxy.https }}
 - name: NO_PROXY

--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -250,7 +250,7 @@ Set Giant Swarm initContainers.
 {{- define "giantswarm.deploymentInitContainers" -}}
 {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
 - name: wait-for-iam-role
-  image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
+  image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2
   command:
     - /bin/sh
     - -c
@@ -258,7 +258,7 @@ Set Giant Swarm initContainers.
 {{- end }}
 {{- if eq .Values.provider "azure" }}
 - name: copy-azure-config-file
-  image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3
+  image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2-python3
   command:
     - /bin/sh
     - -c
@@ -336,4 +336,11 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+The image to use
+*/}}
+{{- define "external-dns.image" -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag }}
 {{- end }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -46,10 +46,10 @@ spec:
       {{- with .Values.shareProcessNamespace }}
       shareProcessNamespace: {{ . }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: {{ .Values.global.securityContext.userID }}
-        runAsGroup: {{ .Values.global.securityContext.groupID }}
-        fsGroup: {{ .Values.global.securityContext.fsGroupID }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -67,23 +67,25 @@ spec:
       containers:
         {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
         - name: "{{ .Release.Name }}-check-iam"
-          image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2
+          image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2
           command:
           - /bin/sh
           - -c
           - while wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep -q {{ template "aws.iam.role" . }} ; do sleep 30 ; done && exit 1
           securityContext:
             readOnlyRootFilesystem: true
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.global.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         - name: external-dns
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.global.image.registry }}/{{ .Values.global.image.name }}:{{ .Values.global.image.tag }}"
-          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          image: {{ include "external-dns.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -92,17 +94,14 @@ spec:
           args:
             - --log-level={{ .Values.logLevel }}
             - --log-format={{ .Values.logFormat }}
-            - --interval={{ default .Values.externalDNS.interval .Values.interval }}
+            - --interval={{ .Values.interval }}
             {{- if .Values.triggerLoopOnEvent }}
             - --events
             {{- end }}
-            {{- if .Values.externalDNS.dryRun }}
-            - --dry-run
-            {{- end }}
-            {{- range .Values.externalDNS.sources }}
+            {{- range .Values.sources }}
             - --source={{ . }}
             {{- end }}
-            - --policy={{ .Values.externalDNS.policy }}
+            - --policy={{ .Values.policy }}
             - --annotation-filter={{- template "annotation.filter" . }}
             {{- include "dnsProvider.flags" . | nindent 12 }}
             {{- if .Values.namespaceFilter }}
@@ -116,9 +115,6 @@ spec:
             - --txt-prefix={{- template "txt.prefix" . }}
             {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
-            {{- end }}
-            {{- range .Values.externalDNS.extraArgs }}
-            - {{ . }}
             {{- end }}
           {{- range .Values.extraArgs }}
             - {{ tpl . $ }}
@@ -149,8 +145,10 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.global.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes (eq .Values.provider "azure") }}
       volumes:
         {{- if eq .Values.provider "azure" }}

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -27,7 +27,6 @@ spec:
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- include "giantswarm.podAnnotations" . }}
       {{- if or .Values.secretConfiguration.enabled .Values.podAnnotations }}
       annotations:
         {{- if .Values.secretConfiguration.enabled }}
@@ -65,20 +64,6 @@ spec:
       initContainers:
         {{- include "giantswarm.deploymentInitContainers" . | nindent 8 }}
       containers:
-        {{- if and (or (eq .Values.provider "aws") (eq .Values.provider "capa")) (eq .Values.aws.access "internal") ( eq .Values.aws.irsa "false") }}
-        - name: "{{ .Release.Name }}-check-iam"
-          image: {{ .Values.image.registry }}/giantswarm/alpine:3.16.2
-          command:
-          - /bin/sh
-          - -c
-          - while wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep -q {{ template "aws.iam.role" . }} ; do sleep 30 ; done && exit 1
-          securityContext:
-            readOnlyRootFilesystem: true
-          {{- with .Values.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        {{- end }}
         - name: external-dns
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -105,9 +105,12 @@ spec:
             - --policy={{ .Values.externalDNS.policy }}
             - --annotation-filter={{- template "annotation.filter" . }}
             {{- include "dnsProvider.flags" . | nindent 12 }}
-            - --metrics-address=:{{ .Values.global.metrics.port }}
-            - --namespace={{ default .Values.externalDNS.namespaceFilter .Values.namespaceFilter }}
-            - --min-event-sync-interval={{ default .Values.externalDNS.minEventSyncInterval .Values.minEventSyncInterval }}
+            {{- if .Values.namespaceFilter }}
+            - --namespace={{ .Values.namespaceFilter }}
+            {{- end }}
+            {{- if .Values.minEventSyncInterval }}
+            - --min-event-sync-interval={{ .Values.minEventSyncInterval }}
+            {{- end }}
             - --registry=txt
             - --txt-owner-id={{- template "txt.owner.id" . }}
             - --txt-prefix={{- template "txt.prefix" . }}
@@ -121,21 +124,13 @@ spec:
             - {{ tpl . $ }}
           {{- end }}
           ports:
-            - name: metrics
+            - name: http
               protocol: TCP
-              containerPort: {{ .Values.global.metrics.port }}
+              containerPort: 7979
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.global.metrics.port }}
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.global.metrics.port }}
-              scheme: HTTP
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
           volumeMounts:
             {{- if eq .Values.provider "azure" }}

--- a/helm/external-dns-app/templates/metrics-service.yaml
+++ b/helm/external-dns-app/templates/metrics-service.yaml
@@ -1,20 +1,21 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-monitoring
+  name: {{ include "external-dns.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: {{ .Values.global.metrics.port | quote }}
-    giantswarm.io/monitoring-app-label: {{ .Chart.Name | quote }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  clusterIP: None
-  ports:
-  - name: metrics
-    port: {{ .Values.global.metrics.port }}
-    targetPort: metrics
+  type: ClusterIP
   selector:
     {{- include "external-dns.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/helm/external-dns-app/templates/np.yaml
+++ b/helm/external-dns-app/templates/np.yaml
@@ -14,7 +14,7 @@ spec:
   - Egress
   ingress:
   - ports:
-    - port: {{ .Values.global.metrics.port }}
+    - port: {{ .Values.service.port }}
       protocol: TCP
   egress:
   - {}

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -15,8 +15,8 @@ spec:
   {{- if .Values.hostNetwork }}
   hostNetwork: true
   hostPorts:
-  - min: {{ .Values.global.metrics.port }}
-    max: {{ .Values.global.metrics.port }}
+  - min: {{ .Values.service.port }}
+    max: {{ .Values.service.port }}
   {{- end }}
   hostPID: false
   privileged: false

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -9,8 +9,8 @@ spec:
   fsGroup:
     rule: 'MustRunAs'
     ranges:
-      - min: {{ .Values.global.securityContext.fsGroupID }}
-        max: {{ .Values.global.securityContext.fsGroupID }}
+      - min: {{ .Values.podSecurityContext.fsGroup }}
+        max: {{ .Values.podSecurityContext.fsGroup }}
   hostIPC: false
   {{- if .Values.hostNetwork }}
   hostNetwork: true
@@ -24,13 +24,13 @@ spec:
   runAsGroup:
     rule: 'MustRunAs'
     ranges:
-      - min: {{ .Values.global.securityContext.groupID }}
-        max: {{ .Values.global.securityContext.groupID }}
+      - min: {{ .Values.podSecurityContext.runAsGroup }}
+        max: {{ .Values.podSecurityContext.runAsGroup }}
   runAsUser:
     rule: 'MustRunAs'
     ranges:
-      - min: {{ .Values.global.securityContext.userID }}
-        max: {{ .Values.global.securityContext.userID }}
+      - min: {{ .Values.podSecurityContext.runAsUser }}
+        max: {{ .Values.podSecurityContext.runAsUser }}
   seLinux:
     rule: RunAsAny
   supplementalGroups:

--- a/helm/external-dns-app/templates/secret.yaml
+++ b/helm/external-dns-app/templates/secret.yaml
@@ -1,17 +1,3 @@
-{{ if and .Values.externalDNS.aws_access_key_id .Values.externalDNS.aws_secret_access_key }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{ .Release.Name }}-route53-credentials"
-  namespace: "{{ .Release.Namespace }}"
-  labels:
-    {{- include "external-dns.labels" . | nindent 4 }}
-data:
-  aws_access_key_id: {{ .Values.externalDNS.aws_access_key_id | b64enc }}
-  aws_secret_access_key: {{ .Values.externalDNS.aws_secret_access_key | b64enc }}
-type: Opaque
----
-{{ end -}}
 {{- if .Values.secretConfiguration.enabled }}
 apiVersion: v1
 kind: Secret

--- a/helm/external-dns-app/values.schema.json
+++ b/helm/external-dns-app/values.schema.json
@@ -221,17 +221,6 @@
                         }
                     }
                 },
-                "metrics": {
-                    "type": "object",
-                    "properties": {
-                        "port": {
-                            "type": "integer"
-                        },
-                        "scrape": {
-                            "type": "boolean"
-                        }
-                    }
-                },
                 "resources": {
                     "type": "object",
                     "properties": {
@@ -277,6 +266,37 @@
         },
         "imagePullSecrets": {
             "type": "array"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
         },
         "logFormat": {
             "type": "string"
@@ -324,6 +344,37 @@
                 }
             }
         },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
         "secretConfiguration": {
             "type": "object",
             "properties": {
@@ -362,6 +413,17 @@
                     "type": "boolean"
                 },
                 "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "port": {
                     "type": "integer"
                 }
             }

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -224,6 +224,10 @@ podLabels: {}
 # Annotations to add to the Pod
 podAnnotations:
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+  prometheus.io/path: /metrics
+  prometheus.io/port: "7979"
+  prometheus.io/scrape: "true"
+  kubectl.kubernetes.io/default-container: external-dns
 
 shareProcessNamespace: false
 
@@ -288,6 +292,33 @@ serviceMonitor:
 
 env: []
 
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+service:
+  port: 7979
+  annotations:
+    giantswarm.io/monitoring-path: /metrics
+    giantswarm.io/monitoring-port: "7979"
+    giantswarm.io/monitoring-app-label: "external-dns-app"
+
 extraVolumes: []
 
 extraVolumeMounts: []
@@ -337,18 +368,6 @@ global:
     # When updating tag make sure to also keep appVersion in Chart.yaml in sync.
     tag: v0.11.0
     pullPolicy: IfNotPresent
-
-  # global.metrics
-  # Metrics configuration options
-  metrics:
-
-    # global.metrics.port
-    # The port to serve metrics on.
-    port: 7979
-
-    # global.metrics.scrape
-    # Enable/disable scraping by Prometheus.
-    scrape: true
 
   # global.resources
   # Set pod resource limits and requests. This is passed as a YAML

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -84,14 +84,6 @@ externalDNS:
   # instances of external-dns.
   annotationFilter: "giantswarm.io/external-dns=managed"
 
-  # externalDNS.aws_access_key_id
-  # Access key ID for the AWS API. Only required when aws.access is 'external'.
-  aws_access_key_id:
-
-  # externalDNS.aws_secret_access_key
-  # Access key secret for the AWS API. Only required when aws.access is 'external'.
-  aws_secret_access_key:
-
   # externalDNS.domainFilterList
   # One or more domains that this instance of external-dns will manage. If
   # no domains are provided then the cluster baseDomain must be provided via

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -34,25 +34,10 @@ aws:
   # be used.
   batchChangeInterval: 10s
 
-  # aws.irsa
-  # Set to true when IAM roles for service accounts is enabled.
-  # It is dynamically set and will be overridden.
-  irsa: "false"
-
   # aws.zonesCacheDuration
   # Set the zones list cache TTL. If left blank then the default will
   # be used.
   zonesCacheDuration: 3h
-
-  # aws.iam
-  # AWS IAM configuration.
-  iam:
-
-    # aws.iam.customRole
-    # If set, allows a user-created role to be assumed. Role must have access to a
-    # policy which allows configuration of Route53 hosted zone(s).
-    # e.g. `customRoleName: route53-manager-role`
-    customRoleName:
 
   # aws.preferCNAME
   # Create CNAME records instead of ALIAS. Will always be set to true when aws.access

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -130,41 +130,7 @@ cluster:
 # crd
 # Configuration options for CRDs.
 crd:
-
-  # crd.backoffLimit
-  # setting this higher means the CRD creation is less likely to be marked
-  # as failed.
-  backoffLimit: 10
-
-  # crd.image
-  image:
-
-    # crd.image.pullPolicy
-    pullPolicy: IfNotPresent
-
-  # crd.install
-  # CRDs are installed by default. If this is disabled then CRDs must
-  # be managed by another method.
   install: true
-
-  # crd.resources
-  resources:
-
-    # crd.resources.requests
-    # Minimum resources requested for the job.
-    requests:
-      cpu: 100m
-      memory: 256Mi
-
-    # crd.resources.limits
-    # Maximum resources available for the job.
-    limits:
-      cpu: 500m
-      memory: 512Mi
-
-  podSecurityContext:
-    runAsGroup: 65534
-    runAsUser: 65534
 
 image:
   name: giantswarm/external-dns

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -340,3 +340,7 @@ clusterID: en2jo
 
 ciliumNetworkPolicy:
   enabled: false
+
+global:
+  image:
+    registry: docker.io

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -103,27 +103,10 @@ externalDNS:
   # - foo.bar.com
   # - baz.bar.com
 
-  # externalDNS.dryRun
-  # Dry run logs what action external-dns would have taken, but doesn't apply them.
-  dryRun: false
-
-  # externalDNS.interval
-  # Interval between synchronisations. Must be in duration format (e.g. `5m`)
-  interval: 5m
-
   # externalDNS.namespaceFilter
   # The namespace to limit sources of endpoints to. If left blank, all
   # namespaces will be used.
   namespaceFilter: kube-system
-
-  # externalDNS.minEventSyncInterval
-  # The minimum interval between two consecutive synchronizations triggered from
-  # kubernetes events in duration format (default: 5s)
-  minEventSyncInterval: 30s
-
-  # externalDNS.policy
-  # Syncing policy between sources and providers.
-  policy: sync
 
   # externalDNS.registry
   # Configuration options relating to ownership of created records.
@@ -138,17 +121,6 @@ externalDNS:
     # String prefix applied to TXT registry records. See
     # https://github.com/kubernetes-sigs/external-dns/blob/master/docs/proposal/registry.md
     txtPrefix: extdns
-
-  # externalDNS.sources
-  # Resource types queried for endpoints.
-  sources:
-  - service
-  # Disable ingress source by default.
-  # - ingress
-
-  # externalDNS.extraArgs
-  # Allows to specify additional arguments to the external-dns deployment.
-  extraArgs: []
 
 # set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
 proxy:
@@ -198,6 +170,16 @@ crd:
       cpu: 500m
       memory: 512Mi
 
+  podSecurityContext:
+    runAsGroup: 65534
+    runAsUser: 65534
+
+image:
+  name: giantswarm/external-dns
+  registry: docker.io
+  tag: v0.11.0
+  pullPolicy: IfNotPresent
+
 imagePullSecrets: []
 
 serviceAccount:
@@ -230,6 +212,11 @@ podAnnotations:
   kubectl.kubernetes.io/default-container: external-dns
 
 shareProcessNamespace: false
+
+podSecurityContext:
+  fsGroup: 65534
+  runAsGroup: 65534
+  runAsUser: 65534
 
 securityContext:
   runAsNonRoot: true
@@ -325,6 +312,13 @@ extraVolumeMounts: []
 
 tolerations: []
 
+resources:
+  limits:
+    memory: 100Mi
+  requests:
+    cpu: 50m
+    memory: 100Mi
+
 nodeSelector: {}
 
 affinity: {}
@@ -334,14 +328,23 @@ topologySpreadConstraints: []
 logLevel: info
 logFormat: text
 
+interval: 5m
 triggerLoopOnEvent: false
 
 terminationGracePeriodSeconds:
 
 sources:
   - service
-  - ingress
-  - crd
+
+policy: sync
+
+# provider
+# Identifies the cloud provider. Currently supported: `aws` and `azure`. This *must*
+# be set. If this is installed as a default app from the default-catalog then this
+# value is set dynamically and will be overridden.
+provider: CHANGEME
+
+extraArgs: []
 
 secretConfiguration:
   enabled: false
@@ -352,54 +355,8 @@ secretConfiguration:
 deploymentStrategy:
   type: Recreate
 
-global:
-
-  # global.image
-  # Configuration options for images.
-  image:
-
-    # global.image.name
-    name: giantswarm/external-dns
-
-    # global.image.registry
-    registry: docker.io
-
-    # global.image.tag
-    # When updating tag make sure to also keep appVersion in Chart.yaml in sync.
-    tag: v0.11.0
-    pullPolicy: IfNotPresent
-
-  # global.resources
-  # Set pod resource limits and requests. This is passed as a YAML
-  # dictionary directly into the deployment manifest.
-  resources:
-    limits:
-      memory: 100Mi
-    requests:
-      cpu: 50m
-      memory: 100Mi
-
-  # global.securityContext
-  securityContext:
-
-    # global.securityContext.fsGroupID
-    fsGroupID: 65534
-
-    # global.securityContext.groupID
-    groupID: 65534
-
-    # global.securityContext.userID
-    userID: 65534
-
 # hostNetwork
 hostNetwork: false
-
-# provider
-# Identifies the cloud provider. Currently supported: `aws` and `azure`. This *must*
-# be set. If this is installed as a default app from the default-catalog then this
-# value is set dynamically and will be overridden.
-provider: CHANGEME
-
 
 ## Do not change any values below; these are specific to Giant Swarm environments.
 

--- a/vendir.yml
+++ b/vendir.yml
@@ -1,0 +1,16 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+- path: vendor
+  contents:
+  - path: external-dns
+    git:
+      url: git@github.com:giantswarm/external-dns-upstream.git
+      ref: v0.13.5
+    includePaths:
+    - charts/**/*
+- path: helm/external-dns-app/templates
+  contents:
+  - path: .
+    directory:
+      path: vendor/external-dns/charts/external-dns/templates


### PR DESCRIPTION
- Service: align to upstream (#243)
- Align deployment for v3 (#255)
- Remove aws credentials values (#266)
- Reorganize changelog
- adapt podSecurityContext in crd-install subchart
- use global.image.registry in crd-install job
- Remove support for KIAM (#278)
- enable vendir

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
