### PR TITLE
Add namespaced feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add minAllowed in VPA to minimize OOM cycle.
 - Add vendir for upstream sync.
+- Add namespaced feature to scope permissions to one namespace.
 
 ### Changed
 

--- a/helm/external-dns-app/templates/clusterrole.yaml
+++ b/helm/external-dns-app/templates/clusterrole.yaml
@@ -1,13 +1,12 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ .Values.namespaced | ternary "Role" "ClusterRole" }}
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 rules:
-{{- if or (has "node" .Values.sources) (has "pod" .Values.sources) (has "service" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "gloo-proxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources) }}
+{{- if and (not .Values.namespaced) (or (has "node" .Values.sources) (has "pod" .Values.sources) (has "service" .Values.sources) (has "contour-httpproxy" .Values.sources) (has "gloo-proxy" .Values.sources) (has "openshift-route" .Values.sources) (has "skipper-routegroup" .Values.sources)) }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list","watch"]

--- a/helm/external-dns-app/templates/clusterrolebinding.yaml
+++ b/helm/external-dns-app/templates/clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ .Values.namespaced | ternary "RoleBinding" "ClusterRoleBinding" }}
 metadata:
   name: {{ printf "%s-viewer" (include "external-dns.fullname" .) }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ .Values.namespaced | ternary "Role" "ClusterRole" }}
   name: {{ template "external-dns.fullname" . }}
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

Allows the user to scope external-dns to just one namespace. Not only filtering by namespace, but also limiting the permissions to just that namespace.

The change comes from upstream. Towards https://github.com/giantswarm/roadmap/issues/411


---

## Checklist

- [x] Added a CHANGELOG entry

