### PR TITLE
remove azure

### DIFF
--- a/helm/external-dns-app/templates/_helpers.tpl
+++ b/helm/external-dns-app/templates/_helpers.tpl
@@ -136,10 +136,6 @@ Set provider specific flags.
 {{ include "domain.list" . }}
 {{- end }}
 
-{{- if eq .Values.provider "azure" }}
-- --azure-config-file=/config/azure.yaml
-{{- end }}
-
 {{- end }}
 
 {{/*
@@ -259,26 +255,6 @@ Set Giant Swarm initContainers.
     - /bin/sh
     - -c
     - counter=5; while ! wget -qO- http://169.254.169.254/latest/meta-data/iam/security-credentials/ | grep {{ template "aws.iam.role" . }}; do echo 'Waiting for iam-role to be available...'; sleep 5; let "counter-=1"  ; if [ "$counter" -eq "0" ]; then exit 1; fi; done
-{{- end }}
-{{- if eq .Values.provider "azure" }}
-- name: copy-azure-config-file
-  image: {{ .Values.global.image.registry }}/giantswarm/alpine:3.16.2-python3
-  command:
-    - /bin/sh
-    - -c
-    # GS clusters have the cloud config file in /etc/kubernetes/config/azure.yaml and we can use it as-is so we just copy it to the desired position.
-    # CAPZ clusters use a JSON file so we convert it to yaml and save it to the desired position.
-    - if [ -f /etc/kubernetes/config/azure.yaml ]; then
-      cp /etc/kubernetes/config/azure.yaml /config/azure.yaml;
-      else
-      cat /etc/kubernetes/azure.json | python3 -c 'import sys, yaml, json; print(yaml.dump(json.loads(sys.stdin.read())))' > /config/azure.yaml;
-      fi
-  volumeMounts:
-    - mountPath: /etc/kubernetes
-      name: etc-kubernetes
-      readOnly: true
-    - mountPath: /config
-      name: config
 {{- end }}
 {{- end -}}
 

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -136,13 +136,8 @@ spec:
               path: /healthz
               port: {{ .Values.global.metrics.port }}
               scheme: HTTP
-          {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts (eq .Values.provider "azure") }}
+          {{- if or .Values.secretConfiguration.enabled .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- if eq .Values.provider "azure" }}
-            - name: config
-              mountPath: /config
-              readOnly: true
-            {{- end }}
             {{- if .Values.secretConfiguration.enabled }}
             - name: secrets
               mountPath: {{ tpl .Values.secretConfiguration.mountPath $ }}
@@ -156,15 +151,8 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.global.resources | nindent 12 }}
-      {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes (eq .Values.provider "azure") }}
+      {{- if or .Values.secretConfiguration.enabled .Values.extraVolumes }}
       volumes:
-        {{- if eq .Values.provider "azure" }}
-        - name: config
-          emptyDir: {}
-        - name: etc-kubernetes
-          hostPath:
-            path: /etc/kubernetes
-        {{- end }}
         {{- if .Values.secretConfiguration.enabled }}
         - name: secrets
           secret:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [ ] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
