### PR TITLE
enable service monitors and disable annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Replace monitoring labels with ServiceMonitor ([#296](https://github.com/giantswarm/external-dns-app/pull/296)).
+
 ## [2.38.1] - 2023-08-04
 
 ### Added

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
-    giantswarm.io/monitoring_basic_sli: "true"
   {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/external-dns-app/templates/metrics-service.yaml
+++ b/helm/external-dns-app/templates/metrics-service.yaml
@@ -3,13 +3,8 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-monitoring
   namespace: {{ .Release.Namespace }}
-  annotations:
-    giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: {{ .Values.global.metrics.port | quote }}
-    giantswarm.io/monitoring-app-label: {{ .Chart.Name | quote }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
-    giantswarm.io/monitoring: "true"
 spec:
   clusterIP: None
   ports:

--- a/helm/external-dns-app/templates/metrics-service.yaml
+++ b/helm/external-dns-app/templates/metrics-service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: metrics
+  - name: http
     port: {{ .Values.global.metrics.port }}
     targetPort: metrics
   selector:

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -276,7 +276,7 @@ serviceMonitor:
 
   ## Relabel configs to apply to samples before ingestion.
   ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
-  relabelings: []
+  relabelings:
     - action: replace
       regex: ;(.*)
       replacement: $1

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -277,13 +277,22 @@ serviceMonitor:
   ## Relabel configs to apply to samples before ingestion.
   ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
   relabelings: []
-  # - sourceLabels: [__meta_kubernetes_pod_node_name]
-  #   separator: ;
-  #   regex: ^(.*)$
-  #   targetLabel: nodename
-  #   replacement: $1
-  #   action: replace
-
+    - action: replace
+      regex: ;(.*)
+      replacement: $1
+      separator: ;
+      sourceLabels:
+      - namespace
+      - __meta_kubernetes_namespace
+      targetLabel: namespace
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_app
+      targetLabel: app
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
   targetLabels: []
 
 env: []

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -241,7 +241,7 @@ dnsPolicy:
 priorityClassName: "giantswarm-critical"
 
 serviceMonitor:
-  enabled: false
+  enabled: true
   # force namespace
   # namespace: monitoring
 

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -246,7 +246,7 @@ serviceMonitor:
   # namespace: monitoring
 
   # Fallback to the prometheus default unless specified
-  # interval: 10s
+  interval: 60s
 
   ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
   # scheme: ""

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -5,3 +5,6 @@ image:
 crd:
   ciliumNetworkPolicy:
     enabled: false
+
+serviceMonitor:
+  enabled: false


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Removes monitoring labels
- enables ServiceMonitor with relabeling included.


Towards https://github.com/giantswarm/roadmap/issues/2628

---

## Checklist

- [x] Added a CHANGELOG entry
