### PR TITLE
Make deployment compliant with PSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make deployment compliant with PSS ([#307](https://github.com/giantswarm/external-dns-app/pull/307)).
+
 ## [2.40.0] - 2023-09-21
 
 ### Changed

--- a/helm/external-dns-app/templates/deployment.yaml
+++ b/helm/external-dns-app/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
         runAsUser: {{ .Values.global.securityContext.userID }}
         runAsGroup: {{ .Values.global.securityContext.groupID }}
         fsGroup: {{ .Values.global.securityContext.fsGroupID }}
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/helm/external-dns-app/templates/psp.yaml
+++ b/helm/external-dns-app/templates/psp.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   fsGroup:
     rule: 'MustRunAs'

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -228,6 +228,7 @@ podAnnotations:
 shareProcessNamespace: false
 
 securityContext:
+  allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 65534
   readOnlyRootFilesystem: true


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
