### PR TITLE
Make CRD installation job compliant with PSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make CRD install job compliant with PSS ([#309](https://github.com/giantswarm/external-dns-app/pull/309)).
+
 ## [2.41.0] - 2023-09-26
 
 ### Changed

--- a/helm/external-dns-app/charts/crd/templates/_helpers.tpl
+++ b/helm/external-dns-app/charts/crd/templates/_helpers.tpl
@@ -3,7 +3,7 @@ CRD install annotations.
 */}}
 {{- define "crd.annotations" -}}
 helm.sh/hook: pre-install,pre-upgrade
-helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+helm.sh/hook-delete-policy: before-hook-creation
 {{- end -}}
 
 {{/*

--- a/helm/external-dns-app/charts/crd/templates/_helpers.tpl
+++ b/helm/external-dns-app/charts/crd/templates/_helpers.tpl
@@ -3,7 +3,7 @@ CRD install annotations.
 */}}
 {{- define "crd.annotations" -}}
 helm.sh/hook: pre-install,pre-upgrade
-helm.sh/hook-delete-policy: before-hook-creation
+helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{/*

--- a/helm/external-dns-app/charts/crd/templates/job.yaml
+++ b/helm/external-dns-app/charts/crd/templates/job.yaml
@@ -18,6 +18,8 @@ spec:
       securityContext:
         runAsUser: {{ .Values.global.securityContext.userID }}
         runAsGroup: {{ .Values.global.securityContext.groupID }}
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -26,7 +28,11 @@ spec:
       containers:
       - name: kubectl
         securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
           readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
         image: {{ .Values.global.image.registry }}/giantswarm/docker-kubectl:1.24.2
         command:
         - sh

--- a/helm/external-dns-app/charts/crd/templates/psp.yaml
+++ b/helm/external-dns-app/charts/crd/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -6,6 +6,7 @@ metadata:
   annotations:
     {{- include "crd.annotations" . | nindent 4 }}
     helm.sh/hook-weight: "-6"
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   labels:
     {{- include "crd.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

This PR:



---

## Checklist

- [x] Added a CHANGELOG entry

## Testing

The instance of external-dns installed as part of Giant Swarm platform releases watches services in the `kube-system` namespace with annotations `giantswarm.io/external-dns=managed` and `external-dns.alpha.kubernetes.io/hostname` matching the clusters base domain. (You can find this in the deployments args `--domain-filter` value)

You can take this example `Service`, apply it to your cluster. Change the `external-dns.alpha.kubernetes.io/hostname` annotation to match your clusters base domain.

then:

- Check external-dns logs for lines like `Desired change: CREATE test.your.configured.domain.gigantic.io CNAME`
- Try to resolve the domain (`https://www.dnstester.net/`)

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: test.your.configured.domain.gigantic.io
    external-dns.alpha.kubernetes.io/ttl: "60"
    giantswarm.io/external-dns: managed
  name: test-external-dns
  namespace: kube-system
spec:
  type: ExternalName
  externalName: www.giantswarm.io
```

For testing upgrades:

- Create the service and check for creation
- Upgrade
- Delete the service and check for deletion

### Default app on AWS releases

- [ ] Fresh install works
- [ ] Upgrade works

### Default app on Azure releases

- [ ] Fresh install works
- [ ] Upgrade works

### Optional app (KVM)

- [ ] Fresh install works
- [ ] Upgrade works
