### PR TITLE
Remove default namespaceFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Remove default namespaceFilter configuration. ([#324](https://github.com/giantswarm/external-dns-app/pull/324)).
+
 ## [3.0.0] - 2023-12-13
 
 ### Added

--- a/helm/external-dns-app/values.yaml
+++ b/helm/external-dns-app/values.yaml
@@ -175,7 +175,7 @@ interval: 5m
 minEventSyncInterval: 30s
 triggerLoopOnEvent: false
 
-namespaceFilter: kube-system
+namespaceFilter: ""
 namespaced: false
 
 sources:


### PR DESCRIPTION
This PR removes the default `namespaceFilter` setting set to `kube-system`. This is a relic from times past when ingress-nginx was a default app.

Nowadays people install ingress-controllers in other namespaces and expect their ingress-controllers to work.

https://github.com/giantswarm/giantswarm/issues/29706
