### PR TITLE
Use external-dns.namespace in our resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   - Add `sourceNamespace` value (used with `namespaced=true`) to watch resources in a namespace different from the deployment namespace.
   - Avoid creating cluster-scoped namespace RBAC when `gatewayNamespace` is set, reducing required permissions.
   - Fix `extraArgs` map handling: boolean values now render as `--flag` / `--no-flag` and string values are properly quoted.
+- Use external-dns.namespace in VPA and NetworkPolicy resources.
 
 ## [3.4.0] - 2026-01-07
 

--- a/diffs/helm__external-dns-app__templates__np.yaml.patch
+++ b/diffs/helm__external-dns-app__templates__np.yaml.patch
@@ -1,6 +1,6 @@
 diff --git a/helm/external-dns-app/templates/np.yaml b/helm/external-dns-app/templates/np.yaml
 new file mode 100644
-index 0000000..6d25a93
+index 0000000..2643b59
 --- /dev/null
 +++ b/helm/external-dns-app/templates/np.yaml
 @@ -0,0 +1,21 @@
@@ -8,7 +8,7 @@ index 0000000..6d25a93
 +apiVersion: networking.k8s.io/v1
 +metadata:
 +  name: {{ .Release.Name }}
-+  namespace: {{ .Release.Namespace }}
++  namespace: {{ include "external-dns.namespace" . }}
 +  labels:
 +    {{- include "external-dns.labels" . | nindent 4 }}
 +spec:

--- a/diffs/helm__external-dns-app__templates__vpa.yaml.patch
+++ b/diffs/helm__external-dns-app__templates__vpa.yaml.patch
@@ -1,6 +1,6 @@
 diff --git a/helm/external-dns-app/templates/vpa.yaml b/helm/external-dns-app/templates/vpa.yaml
 new file mode 100644
-index 0000000..869f2dc
+index 0000000..e27c461
 --- /dev/null
 +++ b/helm/external-dns-app/templates/vpa.yaml
 @@ -0,0 +1,24 @@
@@ -9,7 +9,7 @@ index 0000000..869f2dc
 +kind: VerticalPodAutoscaler
 +metadata:
 +  name: {{ .Release.Name }}
-+  namespace: {{ .Release.Namespace }}
++  namespace: {{ include "external-dns.namespace" . }}
 +  labels:
 +    {{- include "external-dns.labels" . | nindent 4 }}
 +spec:

--- a/helm/external-dns-app/templates/np.yaml
+++ b/helm/external-dns-app/templates/np.yaml
@@ -2,7 +2,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 spec:

--- a/helm/external-dns-app/templates/vpa.yaml
+++ b/helm/external-dns-app/templates/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 spec:

--- a/sync/patches/network-policies/networkpolicy.yaml
+++ b/sync/patches/network-policies/networkpolicy.yaml
@@ -2,7 +2,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 spec:

--- a/sync/patches/vpa/vpa.yaml
+++ b/sync/patches/vpa/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "external-dns.namespace" . }}
   labels:
     {{- include "external-dns.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>


This PR:
- Changes the namespace of VPA and NetPol to match the rest of the chart.

Towards: Github issue #

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
