### PR TITLE
chore: add Artifact Hub metadata to Chart.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Artifact Hub metadata in `Chart.yaml`: `maintainers`, `artifacthub.io/license`, `artifacthub.io/category` and `artifacthub.io/links` annotations. ([roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940))
+
 ## [3.5.0] - 2026-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Artifact Hub metadata in `Chart.yaml`: `maintainers`, `artifacthub.io/license`, `artifacthub.io/category` and `artifacthub.io/links` annotations. ([roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940))
+- Artifact Hub metadata in `Chart.yaml`: `artifacthub.io/license`, `artifacthub.io/category` and `artifacthub.io/links` annotations. ([roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940))
 
 ## [3.5.0] - 2026-05-05
 

--- a/helm/external-dns-app/Chart.yaml
+++ b/helm/external-dns-app/Chart.yaml
@@ -6,9 +6,6 @@ icon: https://s.giantswarm.io/app-icons/external-dns/1/dark.png
 name: external-dns-app
 sources:
   - https://github.com/kubernetes-sigs/external-dns
-maintainers:
-  - name: Giant Swarm
-    url: https://github.com/giantswarm
 annotations:
   io.giantswarm.application.team: cabbage
   io.giantswarm.application.audience: "all"

--- a/helm/external-dns-app/Chart.yaml
+++ b/helm/external-dns-app/Chart.yaml
@@ -6,9 +6,19 @@ icon: https://s.giantswarm.io/app-icons/external-dns/1/dark.png
 name: external-dns-app
 sources:
   - https://github.com/kubernetes-sigs/external-dns
+maintainers:
+  - name: Giant Swarm
+    url: https://github.com/giantswarm
 annotations:
   io.giantswarm.application.team: cabbage
   io.giantswarm.application.audience: "all"
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: networking
+  artifacthub.io/links: |
+    - name: Support
+      url: https://github.com/giantswarm/external-dns-app/issues
+    - name: Upstream project
+      url: https://github.com/kubernetes-sigs/external-dns
 version: 3.5.0
 kubeVersion: ">=1.19.0-0"
 dependencies:


### PR DESCRIPTION
## What
Adds Artifact Hub metadata to the chart:
- `maintainers` (Giant Swarm)
- `artifacthub.io/license: Apache-2.0`
- `artifacthub.io/category: networking`
- `artifacthub.io/links` (support + upstream external-dns project)

## Why
PoC for publishing our charts on Artifact Hub from the gsoci OCI registry — see giantswarm/roadmap#3940. external-dns-app is one of the two representative charts.

No template/values changes; Chart.yaml annotation-only.